### PR TITLE
Add option to disable automatically opening errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ In case you prefer environment variables:
 - ```SIGH_USERNAME```
 - ```SIGH_APP_IDENTIFIER```
 - ```SIGH_TEAM_ID``` (The Team ID, e.g. `Q2CBPK58CA`)
+- `SIGH_DISABLE_OPEN_ERROR` - in case of error, `sigh` won't open Preview with a screenshot of the error when this variable is set.
 
 # How does it work?
 

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -419,7 +419,7 @@ module Sigh
       def snap
         path = "Error#{Time.now.to_i}.png"
         save_screenshot(path, :full => true)
-        system("open '#{path}'")
+        system("open '#{path}'") unless ENV['SIGH_DISABLE_OPEN_ERROR']
       end
 
       def wait_for(method, parameter, success)


### PR DESCRIPTION
This can be fairly annoying, especially when using sigh in a scripted environment.
