### PR TITLE
Open provisioning profile in the background

### DIFF
--- a/bin/sigh
+++ b/bin/sigh
@@ -48,7 +48,7 @@ command :renew do |c|
       output_path = options.output || '.'
       output = File.join(output_path.gsub("~", ENV["HOME"]), file_name)
       FileUtils.mv(path, output)
-      system("open '#{output}'") unless options.skip_install
+      system("open -g '#{output}'") unless options.skip_install
       puts output.green
     end
   end


### PR DESCRIPTION
Installing the provisioning profile doesn't bring up new UI, but takes away focus from the terminal. Passing the `-g` option to `open` should fix that.
