### PR TITLE
Always renew feature

### DIFF
--- a/bin/sigh
+++ b/bin/sigh
@@ -49,6 +49,7 @@ class SighApplication
         path = Sigh::DeveloperCenter.new.run(app, type, options.cert_name, options.force, options.cert_date)
 
         if path
+          file_name = options.filename || File.basename(path)
           if options.filename == nil
             file_name = File.basename(path)
           else

--- a/bin/sigh
+++ b/bin/sigh
@@ -25,13 +25,13 @@ class SighApplication
     global_option '--adhoc', 'By default, sigh will create and renew App Store profiles. Setting this flag will generate Adhoc profiles instead.'
     global_option '--skip_install', 'By default, the certificate will be added on your local machine. Setting this flag will skip this action.'
     global_option '--development', 'Renew the development certificate instead of the production one.'
-    global_option '--force', 'Renew the provisioning profile regardless of state.'
+    global_option '--force', 'Renew non-development provisioning profiles regardless of state.'
 
     global_option '-a', '--identifier STRING', String, 'The bundle identifier of your app.'
     global_option '-u', '--username STRING', String, 'Your Apple ID username.'
     global_option '-n', '--cert_name STRING', String, 'The name of the generated certificate file.'
     global_option '-o', '--output STRING', String, 'The folder in which the file should be generated.'
-    global_option '-d', '--cert_date STRING', String, 'The certificate with the given expiry date used to renew. (ex. "Nov 11, 2017")'
+    global_option '-d', '--cert_date STRING', String, 'The certificate with the given expiry date used to renew. (e.g. "Nov 11, 2017")'
     global_option '-f', '--filename STRING', String, 'Filename to use for the provisioning profile'
 
     command :renew do |c|

--- a/bin/sigh
+++ b/bin/sigh
@@ -32,7 +32,7 @@ class SighApplication
     global_option '-n', '--cert_name STRING', String, 'The name of the generated certificate file.'
     global_option '-o', '--output STRING', String, 'The folder in which the file should be generated.'
     global_option '-d', '--cert_date STRING', String, 'The certificate with the given expiry date used to renew. (ex. "Nov 11, 2017")'
-    global_option '-f', '--filename STRING', String, 'Filename to use for profile'
+    global_option '-f', '--filename STRING', String, 'Filename to use for the provisioning profile'
 
     command :renew do |c|
       c.syntax = 'sigh renew'

--- a/bin/sigh
+++ b/bin/sigh
@@ -25,11 +25,14 @@ class SighApplication
     global_option '--adhoc', 'By default, sigh will create and renew App Store profiles. Setting this flag will generate Adhoc profiles instead.'
     global_option '--skip_install', 'By default, the certificate will be added on your local machine. Setting this flag will skip this action.'
     global_option '--development', 'Renew the development certificate instead of the production one.'
+    global_option '--force', 'Renew the development certificate regardless of state.'
 
     global_option '-a', '--identifier STRING', String, 'The bundle identifier of your app.'
     global_option '-u', '--username STRING', String, 'Your Apple ID username.'
     global_option '-n', '--cert_name STRING', String, 'The name of the generated certificate file.'
     global_option '-o', '--output STRING', String, 'The folder in which the file should be generated.'
+    global_option '-d', '--cert_date STRING', String, 'The certificate with the given expiry date used to renew. (ex. "Nov 11, 2017")'
+    global_option '-f', '--filename STRING', String, 'Filename to use for profile'
 
     command :renew do |c|
       c.syntax = 'sigh renew'
@@ -43,10 +46,14 @@ class SighApplication
         type = Sigh::DeveloperCenter::ADHOC if options.adhoc 
         type = Sigh::DeveloperCenter::DEVELOPMENT if options.development
         
-        path = Sigh::DeveloperCenter.new.run(app, type, options.cert_name)
+        path = Sigh::DeveloperCenter.new.run(app, type, options.cert_name, options.force, options.cert_date)
 
         if path
-          file_name = File.basename(path)
+          if options.filename == nil
+            file_name = File.basename(path)
+          else
+            file_name = options.filename
+          end
           output_path = options.output || '.'
           output = File.join(output_path.gsub("~", ENV["HOME"]), file_name)
           FileUtils.mv(path, output)

--- a/bin/sigh
+++ b/bin/sigh
@@ -25,7 +25,7 @@ class SighApplication
     global_option '--adhoc', 'By default, sigh will create and renew App Store profiles. Setting this flag will generate Adhoc profiles instead.'
     global_option '--skip_install', 'By default, the certificate will be added on your local machine. Setting this flag will skip this action.'
     global_option '--development', 'Renew the development certificate instead of the production one.'
-    global_option '--force', 'Renew the development certificate regardless of state.'
+    global_option '--force', 'Renew the provisioning profile regardless of state.'
 
     global_option '-a', '--identifier STRING', String, 'The bundle identifier of your app.'
     global_option '-u', '--username STRING', String, 'Your Apple ID username.'

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -220,7 +220,7 @@ module Sigh
             end
 
             # We found the correct certificate
-            if force && type != DEVELOPMENT
+            if force and type != DEVELOPMENT
               provisioningProfileId = current_cert['provisioningProfileId']
               renew_profile(provisioningProfileId, type, cert_date) # This one needs to be forcefully renewed
               return maintain_app_certificate(app_identifier, type, false, cert_date) # recursive

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -220,7 +220,7 @@ module Sigh
             end
 
             # We found the correct certificate
-            if force
+            if force && type != DEVELOPMENT
               provisioningProfileId = current_cert['provisioningProfileId']
               renew_profile(provisioningProfileId, type, cert_date) # This one needs to be forcefully renewed
               return maintain_app_certificate(app_identifier, type, false, cert_date) # recursive

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -168,7 +168,6 @@ module Sigh
     end
 
     def run(app_identifier, type, cert_name = nil, force, cert_date)
-
       cert = maintain_app_certificate(app_identifier, type, force, cert_date)
 
       type_name = type
@@ -416,7 +415,10 @@ module Sigh
           end
         end
 
-        raise "Could not find a Certificate. Please open #{current_url} and make sure you have a signing profile created.".red
+        error_message_no_cert_with_date = "Could not find a Certificate with expiry date '#{cert_date}'. Please open #{current_url} and make sure you have a signing profile created.".red
+        error_message_no_cert = "Could not find a Certificate. Please open #{current_url} and make sure you have a signing profile created.".red
+
+        raise cert_date ? error_message_no_cert_with_date : error_message_no_cert
       end
 
       # Download a file from the dev center, by using a HTTP client. This will return the content of the file

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -402,7 +402,7 @@ module Sigh
           if type != DEVELOPMENT and current_cert['typeString'] == 'iOS Distribution' 
             # The other profiles are push profiles
             # We only care about the distribution profile
-            if cert_date == nil
+            unless cert_date
               return current_cert # mostly we only care about the 'certificateId'
             else
               if current_cert['expirationDateString'] == cert_date

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -167,8 +167,9 @@ module Sigh
       raise "Could not open Developer Center" unless result['status'] == 'success'
     end
 
-    def run(app_identifier, type, cert_name = nil)
-      cert = maintain_app_certificate(app_identifier, type)
+    def run(app_identifier, type, cert_name = nil, force, cert_date)
+
+      cert = maintain_app_certificate(app_identifier, type, force, cert_date)
 
       type_name = type
       type_name = "Distribution" if type == APPSTORE # both enterprise and App Store
@@ -181,7 +182,7 @@ module Sigh
       return output_path
     end
 
-    def maintain_app_certificate(app_identifier, type)
+    def maintain_app_certificate(app_identifier, type, force, cert_date)
       begin
         if type == DEVELOPMENT 
           visit PROFILES_URL_DEV
@@ -220,11 +221,15 @@ module Sigh
             end
 
             # We found the correct certificate
-            if current_cert['status'] == 'Active'
+            if force
+              provisioningProfileId = current_cert['provisioningProfileId']
+              renew_profile(provisioningProfileId, type, cert_date) # This one needs to be forcefully renewed
+              return maintain_app_certificate(app_identifier, type, false, cert_date) # recursive
+            elsif current_cert['status'] == 'Active'
               return download_profile(details['provisioningProfile']['provisioningProfileId']) # this one is already finished. Just download it.
             elsif ['Expired', 'Invalid'].include?current_cert['status']
-              renew_profile(current_cert['provisioningProfileId'], type) # This one needs to be renewed
-              return maintain_app_certificate(app_identifier, type) # recursive
+              renew_profile(current_cert['provisioningProfileId'], type, cert_date) # This one needs to be renewed
+              return maintain_app_certificate(app_identifier, type, false, cert_date) # recursive
             end
 
             break
@@ -233,18 +238,18 @@ module Sigh
 
         Helper.log.info "Could not find existing profile. Trying to create a new one."
         # Certificate does not exist yet, we need to create a new one
-        create_profile(app_identifier, type)
+        create_profile(app_identifier, type, cert_date)
         # After creating the profile, we need to download it
-        return maintain_app_certificate(app_identifier, type) # recursive
+        return maintain_app_certificate(app_identifier, type, false, cert_date) # recursive
 
       rescue => ex
         error_occured(ex)
       end
     end
 
-    def create_profile(app_identifier, type)
+    def create_profile(app_identifier, type, cert_date)
       Helper.log.info "Creating new profile for app '#{app_identifier}' for type '#{type}'.".yellow
-      certificate = code_signing_certificate(type)
+      certificate = code_signing_certificate(type, cert_date)
 
       create_url = "https://developer.apple.com/account/ios/profile/profileCreate.action"
       visit create_url
@@ -314,8 +319,8 @@ module Sigh
       wait_for_elements('.row-details')
     end
 
-    def renew_profile(profile_id, type)
-      certificate = code_signing_certificate type
+    def renew_profile(profile_id, type, cert_date)
+      certificate = code_signing_certificate(type, cert_date)
 
       details_url = "https://developer.apple.com/account/ios/profile/profileEdit.action?type=&provisioningProfileId=#{profile_id}"
       Helper.log.info "Renewing provisioning profile '#{profile_id}' using URL '#{details_url}'"
@@ -379,7 +384,7 @@ module Sigh
         # "certificateTypeDisplayId"=>"...",
         # "serialNum"=>"....",
         # "typeString"=>"iOS Distribution"},
-      def code_signing_certificate(type)
+      def code_signing_certificate(type, cert_date)
         certs_url = "https://developer.apple.com/account/ios/certificate/certificateList.action?type="
         certs_url << "distribution" if type != DEVELOPMENT
         certs_url << "development" if type == DEVELOPMENT
@@ -398,8 +403,15 @@ module Sigh
           if type != DEVELOPMENT and current_cert['typeString'] == 'iOS Distribution' 
             # The other profiles are push profiles
             # We only care about the distribution profile
-            return current_cert # mostly we only care about the 'certificateId'
-          elsif type == DEVELOPMENT and current_cert['typeString'] == 'iOS Development' 
+            if cert_date == nil
+              return current_cert # mostly we only care about the 'certificateId'
+            else
+              if current_cert['expirationDateString'] == cert_date
+                Helper.log.info "Certificate ID '#{current_cert['certificateId']}' with expiry date '#{current_cert['expirationDateString']}' located"
+                return current_cert
+              end
+            end
+          elsif type == DEVELOPMENT and current_cert['typeString'] == 'iOS Development'
             return current_cert # mostly we only care about the 'certificateId'
           end
         end


### PR DESCRIPTION
I had some issues renewing development profiles with --force. So I disabled the use of --force when --development is used (line 223).
Not sure if that is a bug of something I introduced (It doesn't look like I did...). Please check.

Basically it's now possible to always renew an (enterprise) profile, give the date of the certificate with which you want to sign the profile, and enter a filename for the generated profile. I have created the -d option to use a date because enterprise certificates are named the same. This was the only way to differentiate.

Hopefully other people can use these features as well.
