### PR TITLE
Add default args to developer_center `run'

### DIFF
--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -169,7 +169,7 @@ module Sigh
       raise "Could not open Developer Center" unless result['status'] == 'success'
     end
 
-    def run(app_identifier, type, cert_name = nil, force, cert_date)
+    def run(app_identifier, type, cert_name = nil, force = false, cert_date = nil)
       cert = maintain_app_certificate(app_identifier, type, force, cert_date)
 
       type_name = type


### PR DESCRIPTION
Fixed errors running sign from fastlane cause by not specifying force and cert_date.

For example I would previously get the following errors:
FATAL [2015-02-04 20:19:17.04]: wrong number of arguments (2 for 4..5)
FATAL [2015-02-04 20:19:17.04]: fastlane finished with errors
/Library/Ruby/Gems/2.0.0/gems/sigh-0.2.3/lib/sigh/developer_center.rb:172:in `run': wrong number of arguments (2 for 4..5) (ArgumentError)
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/actions/sigh.rb:21:in`run'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/fast_file.rb:81:in `block (2 levels) in method_missing'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/actions/actions_helper.rb:29:in`execute_action'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/fast_file.rb:80:in `block in method_missing'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/fast_file.rb:79:in`chdir'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/fast_file.rb:79:in `method_missing'
    from (eval):27:in`block (2 levels) in parse'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/runner.rb:18:in `call'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/runner.rb:18:in`block in execute'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/runner.rb:12:in `chdir'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/runner.rb:12:in`execute'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/lane_manager.rb:15:in `block in cruise_lanes'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/lane_manager.rb:14:in`each'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/lib/fastlane/lane_manager.rb:14:in `cruise_lanes'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/bin/fastlane:31:in`block (2 levels) in run'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/command.rb:180:in `call'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/command.rb:180:in`call'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/command.rb:155:in `run'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/runner.rb:421:in`run_active_command'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/runner.rb:81:in `run!'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/delegates.rb:8:in`run!'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/bin/fastlane:59:in `run'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane-0.1.7/bin/fastlane:63:in`<top (required)>'
    from /usr/bin/fastlane:23:in `load'
    from /usr/bin/fastlane:23:in`<main>'
