### PR TITLE
Adds ability to specify which certificate to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,16 @@ To renew a valid profile with a different certificate, look up the expiry date o
 
     sigh --force -a com.krausefx.app -u username -d "Nov 11, 2017"
 
+By default, ```sigh``` will include all certificates on development profiles, and first certificate on other types. If you need to specify which certificate to use you can either set it's name to `SIGH_CERTIFICATE` environment variable, or pass expiry date of the certificate as argument:
+
+    sigh -a com.krausefx.app -d "Nov 11, 2017"
 
 ## Environment Variables
 In case you prefer environment variables:
 
 - ```SIGH_USERNAME```
 - ```SIGH_APP_IDENTIFIER```
+- ```SIGH_CERTIFICATE```
 - ```SIGH_TEAM_ID``` (The Team ID, e.g. `Q2CBPK58CA`)
 - `SIGH_DISABLE_OPEN_ERROR` - in case of error, `sigh` won't open Preview with a screenshot of the error when this variable is set.
 

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -200,7 +200,7 @@ module Sigh
 
           if details['provisioningProfile']['appId']['identifier'] == app_identifier
             # that's an Ad Hoc profile. I didn't find a better way to detect if it's one ... skipping it
-            next if type == APPSTORE and details['provisioningProfile']['deviceCount'] > 0
+            next if type == APPSTORE && details['provisioningProfile']['deviceCount'] > 0
 
             # that's an App Store profile ... skipping it
             next if type != APPSTORE && details['provisioningProfile']['deviceCount'] == 0

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -423,7 +423,7 @@ module Sigh
           end
         end
 
-        return ret_certs unless !ret_certs.empty?
+        return ret_certs unless ret_certs.empty?
 
         predicates = []
         predicates << "name: #{certificate_name}" if certificate_name


### PR DESCRIPTION
Now you can set which certificate to use though env variable `SIGH_CERTIFICATE`. If none of `SIGH_CERTIFICATE` or expiry date params set, it'll include all certificates on development profiles, and only first on production profiles.

For further consideration:
There are 2 options to specify certificate which are implemented, and 1 could be. To list them:
1. Expiry date: despite the fact that it was already [implemented](https://github.com/KrauseFx/sigh#advanced) people [kept](https://github.com/KrauseFx/sigh/issues/17) [asking](https://github.com/KrauseFx/sigh/issues/24) for it.
2. Certificate name (like `'Almas Sapargali'`): that's what I've implemented in this PR. It may be ambiguous sometimes, since we may have many certificates with same name. In this case all of them gets used.
3. Certificate ID aka 'the right way ©': while being the preferred way, I found it quite confusing, because DevCenter uses another ID for certificates, not what we see in Keychain Access.

I suggest to pick one of these and move with it.

Also, this PR includes a few Ruby refactoring.
