### PR TITLE
Extending fastlane_core things

### DIFF
--- a/bin/sigh
+++ b/bin/sigh
@@ -43,14 +43,14 @@ class SighApplication
         app = app_identifier(options)
         username(options)
 
-        type = FastlaneCore::DeveloperCenter::APPSTORE
-        type = FastlaneCore::DeveloperCenter::ADHOC if options.adhoc 
-        type = FastlaneCore::DeveloperCenter::DEVELOPMENT if options.development
+        type = Sigh::DeveloperCenter::APPSTORE
+        type = Sigh::DeveloperCenter::ADHOC if options.adhoc 
+        type = Sigh::DeveloperCenter::DEVELOPMENT if options.development
 
         ENV['SIGH_CERTIFICATE'] = options.cert_owner if options.cert_owner
         ENV['SIGH_CERTIFICATE_EXPIRE_DATE'] = options.cert_date if options.cert_date
 
-        path = FastlaneCore::DeveloperCenter.new.run(app, type, options.cert_name, options.force)
+        path = Sigh::DeveloperCenter.new.run(app, type, options.cert_name, options.force)
 
         if path
           file_name = options.filename || File.basename(path)

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -1,8 +1,8 @@
 require 'fastlane_core/developer_center/developer_center'
 require 'sigh/developer_center_signing'
 
-module FastlaneCore
-  class DeveloperCenter
+module Sigh
+  class DeveloperCenter < FastlaneCore::DeveloperCenter
     # Types of certificates
     APPSTORE = "AppStore"
     ADHOC = "AdHoc"

--- a/lib/sigh/developer_center_signing.rb
+++ b/lib/sigh/developer_center_signing.rb
@@ -1,5 +1,5 @@
-module FastlaneCore
-  class DeveloperCenter
+module Sigh
+  class DeveloperCenter < FastlaneCore::DeveloperCenter
     # Returns a array of hashes, that contains information about the iOS certificate
     # @example
       # [{"certRequestId"=>"B23Q2P396B",


### PR DESCRIPTION
@KrauseFx This now extends the `fastlane_core` classes so that things won't clash between tools

:warning: :warning: I could not run `rspec` because it uses your Apple ID stuff so I have no idea if it will pass the tests but running these changed worked for me :grimacing: 

**THIS SHOULD BE HIGHLY TESTED BEFORE MERGING**
