### PR TITLE
If provisioning profile name is set, search for that one

### DIFF
--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -51,7 +51,7 @@ module Sigh
 
         certs = post_ajax(@list_certs_url)
 
-        profile_name = Sigh.config[:provisioning_file_name]
+        profile_name = Sigh.config[:provisioning_name]
 
         Helper.log.info "Checking if profile is available. (#{certs['provisioningProfiles'].count} profiles found)"
         required_cert_types = (@type == DEVELOPMENT ? ['iOS Development'] : ['iOS Distribution', 'iOS UniversalDistribution'])

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -50,6 +50,8 @@ module Sigh
 
         certs = post_ajax(@list_certs_url)
 
+        profile_name = Sigh.config[:provisioning_file_name]
+
         Helper.log.info "Checking if profile is available. (#{certs['provisioningProfiles'].count} profiles found)"
         required_cert_types = (@type == DEVELOPMENT ? ['iOS Development'] : ['iOS Distribution', 'iOS UniversalDistribution'])
         certs['provisioningProfiles'].each do |current_cert|
@@ -58,6 +60,9 @@ module Sigh
           details = profile_details(current_cert['provisioningProfileId'])
 
           if details['provisioningProfile']['appId']['identifier'] == Sigh.config[:app_identifier]
+
+            next if profile_name != nil && details['provisioningProfile']['name'] != profile_name
+
             # that's an Ad Hoc profile. I didn't find a better way to detect if it's one ... skipping it
             next if @type == APPSTORE && details['provisioningProfile']['deviceCount'] > 0
 

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -61,7 +61,7 @@ module Sigh
 
           if details['provisioningProfile']['appId']['identifier'] == Sigh.config[:app_identifier]
 
-            next if profile_name != nil && details['provisioningProfile']['name'] != profile_name
+            next if profile_name && details['provisioningProfile']['name'] != profile_name
 
             # that's an Ad Hoc profile. I didn't find a better way to detect if it's one ... skipping it
             next if @type == APPSTORE && details['provisioningProfile']['deviceCount'] > 0


### PR DESCRIPTION
The parameter was used only when creating a new profile. I've added the check when choosing a profile to renew or download directly.
