### PR TITLE
[Resolves #58] Installs profile in Xcode profile dir

### DIFF
--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -4,19 +4,37 @@ module Sigh
       path = Sigh::DeveloperCenter.new.run
 
       return nil unless path
-      
+
       if Sigh.config[:filename]
         file_name = Sigh.config[:filename]
       else
         file_name = File.basename(path)
       end
-      
+
       output = File.join(Sigh.config[:output_path].gsub("~", ENV["HOME"]), file_name)
       (FileUtils.mv(path, output) rescue nil) # in case it already exists
-      system("open -g '#{output}'") unless Sigh.config[:skip_install]
+
+      install_profile(output) unless Sigh.config[:skip_install]
+
       puts output.green
 
-      return File.expand_path(output)      
+      return File.expand_path(output)
+    end
+
+    def self.install_profile(profile)
+      Helper.log.info "Installing provisioning profile..."
+      profile_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
+      profile_filename = ENV["SIGH_UDID"] + ".mobileprovision"
+      destination = profile_path + profile_filename
+
+      # copy to Xcode provisioning profile directory
+      FileUtils.copy profile, destination
+
+      if File.exists? destination
+        Helper.log.info "Profile installed at \"#{destination}\""
+      else
+        raise "Failed installation of provisioning profile at location: #{destination}".red
+      end
     end
   end
 end

--- a/spec/developer_spec.rb
+++ b/spec/developer_spec.rb
@@ -1,11 +1,18 @@
 require 'spec_helper'
 
-describe "Create certificates" do 
-  it 'AppStore, Development and Ad Hoc' do
+describe "Create certificates" do
+  regular_apple_id = "felix@sunapps.net"
+  enterprise_apple_id = "felix.krause@sunapps.net"
+
+  before :each do
     system("rm -rf /tmp/fastlane_core/")
+  end
+
+  it 'AppStore, Development and Ad Hoc' do
+    # system("rm -rf /tmp/fastlane_core/")
     # Regular
-    ENV["DELIVER_USER"] = "felix@sunapps.net"
-    
+    ENV["DELIVER_USER"] = regular_apple_id
+
     Sigh::DeveloperCenter.new.run('net.sunapps.7', Sigh::DeveloperCenter::APPSTORE)
     Sigh::DeveloperCenter.new.run('net.sunapps.7', Sigh::DeveloperCenter::DEVELOPMENT)
     Sigh::DeveloperCenter.new.run('net.sunapps.7', Sigh::DeveloperCenter::ADHOC)
@@ -17,8 +24,16 @@ describe "Create certificates" do
 
 
     # Enterprise
-    ENV["DELIVER_USER"] = "felix.krause@sunapps.net"
+    ENV["DELIVER_USER"] = enterprise_apple_id
     Sigh::DeveloperCenter.new.run('net.sunapps.*', Sigh::DeveloperCenter::APPSTORE)
     expect(File.exists?(File.join(path, "Distribution_net.sunapps.*.mobileprovision"))).to equal(true)
+  end
+
+  it "Installs the provisioning profile in the Xcode profile path" do
+    # Enterprise
+    ENV["DELIVER_USER"] = enterprise_apple_id
+    install_path = "~/Library/MobileDevice/Provisioning Profiles/#{ENV["SIGH_UDID"]}.mobileprovision"
+    Sigh::DeveloperCenter.new.run('net.sunapps.*', Sigh::DeveloperCenter::APPSTORE)
+    expect(File.exists?(install_path)).to equal(true)
   end
 end


### PR DESCRIPTION
This adds a step to Sigh that installs the *.mobileprovision file in the same directory and filename format that xcode installs to, and xcodebuild searches ("~/Library/MobileDevices/Provisioning Profiles/").

I added a _proposed_ test to the spec, but since tests aren't currently working for Sigh, it remains only a proposal. If we ever figure out how to get tests to work (mock the dev portal?) this test should be ready to go.
