### PR TITLE
[WIP] Manage provisioning profiles locally

### DIFF
--- a/bin/sigh
+++ b/bin/sigh
@@ -50,8 +50,12 @@ class SighApplication
     command :manage do |c|
       c.syntax = 'sigh manage'
       c.description = 'Manage installed provisioning profiles on your system.'
+      
       c.option '-e', '--clean_expired', 'Remove all expired provisioning profiles.'
+      c.example 'Remove non-wildcard iOS Team Provisioning e.g. "iOSTeam Provisioning Profile: *" survives and "iOSTeam Provisioning Profile: com.company.app" moves to .Trash', 'sigh manage -p "iOS\ {0,1}Team Provisioning Profile: \w"'
+
       c.option '-p', '--clean_pattern STRING', String, 'Remove any provisioning profiles that matches the pattern.'
+
 
       c.action do |args, options|
         Sigh::Manager.new.run(options, args)

--- a/bin/sigh
+++ b/bin/sigh
@@ -47,6 +47,15 @@ class SighApplication
       end
     end
 
+    command :manage do |c|
+      c.syntax = 'sigh manage'
+      c.description = 'Manage installed provisioning profiles on your system'
+
+      c.action do |args, options|
+        Sigh::Manager.new.run(options, args)
+      end
+    end
+
     default_command :renew
 
     run!

--- a/bin/sigh
+++ b/bin/sigh
@@ -49,9 +49,9 @@ class SighApplication
 
     command :manage do |c|
       c.syntax = 'sigh manage'
-      c.description = 'Manage installed provisioning profiles on your system'
-      c.option '-q', '--clean_team_provisioning', String, 'Remove non-wildcard iOS Team Provisioning e.g. "iOSTeam Provisioning Profile: *" survives and "iOSTeam Provisioning Profile: com.company.app" moves to .Trash'
-      c.option '-p', '--clean_custom_pattern STRING', String, 'Remove any provisioning profiles that matches the pattern. Takes precedence over -q'
+      c.description = 'Manage installed provisioning profiles on your system.'
+      c.option '-e', '--clean_expired', 'Remove all expired provisioning profiles.'
+      c.option '-p', '--clean_pattern STRING', String, 'Remove any provisioning profiles that matches the pattern.'
 
       c.action do |args, options|
         Sigh::Manager.new.run(options, args)

--- a/bin/sigh
+++ b/bin/sigh
@@ -50,6 +50,8 @@ class SighApplication
     command :manage do |c|
       c.syntax = 'sigh manage'
       c.description = 'Manage installed provisioning profiles on your system'
+      c.option '-q', '--clean_team_provisioning', String, 'Remove non-wildcard iOS Team Provisioning e.g. "iOSTeam Provisioning Profile: *" survives and "iOSTeam Provisioning Profile: com.company.app" moves to .Trash'
+      c.option '-p', '--clean_custom_pattern STRING', String, 'Remove any provisioning profiles that matches the pattern. Takes precedence over -q'
 
       c.action do |args, options|
         Sigh::Manager.new.run(options, args)

--- a/lib/sigh.rb
+++ b/lib/sigh.rb
@@ -2,6 +2,7 @@ require 'sigh/version'
 require 'sigh/dependency_checker'
 require 'sigh/developer_center'
 require 'sigh/resign'
+require 'sigh/manager'
 
 require 'fastlane_core'
 

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -60,18 +60,21 @@ module Sigh
     def list_profiles
       profiles = load_profiles
 
-      Helper.log.info "Provisioning profiles installed:"
-
+      Helper.log.info "Provisioning profiles installed"
+      Helper.log.info "Valid profiles:"
       profiles_valid = profiles.select { |profile| profile["ExpirationDate"] > DateTime.now }
       profiles_valid.each do |profile|
-          Helper.log.info profile["Name"].green
+        Helper.log.info profile["Name"].green
       end
       
+      Helper.log.info "-----------------"
+      Helper.log.info "Expired profiles:"
       profiles_expired = profiles.select { |profile| profile["ExpirationDate"] < DateTime.now }
       profiles_expired.each do |profile|
-          Helper.log.info profile["Name"].red
+        Helper.log.info profile["Name"].red
       end
       
+      Helper.log.info "-------"
       Helper.log.info "Summary"
       Helper.log.info "#{profiles.length} installed profiles"
       Helper.log.info "#{profiles_expired.length} are expired"

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -65,25 +65,36 @@ module Sigh
     def list_profiles
       profiles = load_profiles
 
+      now = DateTime.now
+      soon = (Date.today + 30).to_datetime
+
       Helper.log.info "Provisioning profiles installed"
-      Helper.log.info "Valid profiles:"
-      profiles_valid = profiles.select { |profile| profile["ExpirationDate"] > DateTime.now }
+      Helper.log.info "Valid:"
+      profiles_valid = profiles.select { |profile| profile["ExpirationDate"] > now && profile["ExpirationDate"] > soon }
       profiles_valid.each do |profile|
         Helper.log.info profile["Name"].green
       end
+
+      Helper.log.info ""
+      Helper.log.info "Expiring within 30 day:"
+      profiles_soon = profiles.select { |profile| profile["ExpirationDate"] > now && profile["ExpirationDate"] < soon }
+      profiles_soon.each do |profile|
+        Helper.log.info profile["Name"].yellow
+      end      
       
-      Helper.log.info "-----------------"
-      Helper.log.info "Expired profiles:"
-      profiles_expired = profiles.select { |profile| profile["ExpirationDate"] < DateTime.now }
+      Helper.log.info ""
+      Helper.log.info "Expired:"
+      profiles_expired = profiles.select { |profile| profile["ExpirationDate"] < now }
       profiles_expired.each do |profile|
         Helper.log.info profile["Name"].red
       end
       
-      Helper.log.info "-------"
+      Helper.log.info ""
       Helper.log.info "Summary"
       Helper.log.info "#{profiles.length} installed profiles"
-      Helper.log.info "#{profiles_expired.length} are expired"
-      Helper.log.info "#{profiles_valid.length} are valid"
+      Helper.log.info "#{profiles_expired.length} are expired".red
+      Helper.log.info "#{profiles_soon.length} are valid but will expire within 30 days".yellow
+      Helper.log.info "#{profiles_valid.length} are valid".green
     end
 
     def cleanup_profiles(pattern = nil)

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -45,10 +45,9 @@ module Sigh
     end
 
     def list_profiles
-      profiles_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
-      profiles = Dir[profiles_path + "*.mobileprovision"]
+      profiles_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/*.mobileprovision"
       now = DateTime.now
-      profiles.each do |profile_path|
+      Dir[profiles_path].each do |profile_path|
         profile_plist = Plist::parse_xml(`security cms -D -i '#{profile_path}'`)
         if now < profile_plist["ExpirationDate"]
           Helper.log.info(profile_plist["Name"].green)

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -99,6 +99,8 @@ module Sigh
         profiles << profile
       end
 
+      profiles = profiles.sort_by {|profile| profile["Name"].downcase}
+
       return profiles
     end
   end

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -105,7 +105,7 @@ module Sigh
         Helper.log.info profile["Name"].red
       end
 
-      if agree("Delete these provisioning profiles? (y/n)  ", true)
+      if agree("Delete these provisioning profiles #{profiles.length}? (y/n)  ", true)
         Helper.log.info "Deleting #{profiles.length} profiles"
         profiles.each do |profile|
           File.delete profile["Path"]

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -1,3 +1,5 @@
+require 'plist'
+
 module Sigh
   class Manager
     def run(options, args)
@@ -45,8 +47,14 @@ module Sigh
     def list_profiles
       profiles_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
       profiles = Dir[profiles_path + "*.mobileprovision"]
-      profiles.each do |profile|
-        Helper.log.info profile
+      now = DateTime.now
+      profiles.each do |profile_path|
+        profile_plist = Plist::parse_xml(`security cms -D -i '#{profile_path}'`)
+        if now < profile_plist["ExpirationDate"]
+          Helper.log.info(profile_plist["Name"].green)
+        else
+          Helper.log.info(profile_plist["Name"].red)
+        end
       end
     end
 

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -62,20 +62,20 @@ module Sigh
 
       Helper.log.info "Provisioning profiles installed:"
 
-      now = DateTime.now
-      profiles_expired_count = 0
-      
-      profiles.each do |profile|
-        if now < profile["ExpirationDate"]
-          Helper.log.info(profile["Name"].green)
-        else
-          profiles_expired_count += 1
-          Helper.log.info(profile["Name"].red)
-        end
+      profiles_valid = profiles.select { |profile| profile["ExpirationDate"] > DateTime.now }
+      profiles_valid.each do |profile|
+          Helper.log.info profile["Name"].green
       end
+      
+      profiles_expired = profiles.select { |profile| profile["ExpirationDate"] < DateTime.now }
+      profiles_expired.each do |profile|
+          Helper.log.info profile["Name"].red
+      end
+      
+      Helper.log.info "Summary"
       Helper.log.info "#{profiles.length} installed profiles"
-      Helper.log.info "#{profiles_expired_count} are expired"
-      Helper.log.info "#{profiles.length - profiles_expired_count} are valid"
+      Helper.log.info "#{profiles_expired.length} are expired"
+      Helper.log.info "#{profiles_valid.length} are valid"
     end
 
     def cleanup_profiles

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -75,7 +75,7 @@ module Sigh
       end
       Helper.log.info "#{profiles.length} installed profiles"
       Helper.log.info "#{profiles_expired_count} are expired"
-      Helper.log.info "#{profiles.length - profiles_expired_count} are still valid"
+      Helper.log.info "#{profiles.length - profiles_expired_count} are valid"
     end
 
     def cleanup_profiles

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -1,5 +1,10 @@
 module Sigh
   class Manager
+    def run(options, args)
+      Helper.log.info "Profiles"
+      list_profiles
+    end
+
     def self.start
       path = Sigh::DeveloperCenter.new.run
 
@@ -36,5 +41,14 @@ module Sigh
         raise "Failed installation of provisioning profile at location: #{destination}".red
       end
     end
+
+    def list_profiles
+      profiles_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
+      profiles = Dir[profiles_path + "*.mobileprovision"]
+      profiles.each do |profile|
+        Helper.log.info profile
+      end
+    end
+
   end
 end

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -11,7 +11,7 @@ module Sigh
       if command == LIST
         list_profiles
       elsif command == CLEANUP
-        # NOOP
+        cleanup_profiles
       end
     end
 
@@ -58,9 +58,10 @@ module Sigh
     end
 
     def list_profiles
-      Helper.log.info "Provisioning profiles installed:"
-      
       profiles = load_profiles
+
+      Helper.log.info "Provisioning profiles installed:"
+
       now = DateTime.now
       profiles_expired_count = 0
       
@@ -77,7 +78,17 @@ module Sigh
       Helper.log.info "#{profiles.length - profiles_expired_count} are still valid"
     end
 
+    def cleanup_profiles
+      profiles = load_profiles.select { |profile| profile["ExpirationDate"] < DateTime.now }
+
+      Helper.log.info "Deleting #{profiles.length} profiles"
+      profiles.each do |profile|
+        File.delete profile["Path"]
+      end
+    end
+
     def load_profiles
+      Helper.log.info "Loading Provisioning profiles from ~/Library/MobileDevice/Provisioning Profiles/"
       profiles_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/*.mobileprovision"
       profile_paths = Dir[profiles_path]
 


### PR DESCRIPTION
When you are added to 10+ iOS/OSX development teams and add those teams to Xcode you end up with a crazy amount of provisioning profiles. Currently I have 413 installed of which 124 are expired :disappointed:.

So I propose to add `sigh manage (list|cleanup)` for managing provisioning profiles locally.

Please bare with me since it is my first go at ruby :smile_cat: 
### Todo
- [ ] Update README.md
- [x] `sigh manage` to list all installed provisioning profiles.
- [x] `sigh manage -e` to delete expired provisioning profiles.
- [x] `sigh manage -p PATTERN` to delete provisioning profiles matching a pattern.
- [ ] tests?
