### PR TITLE
Manage provisioning profiles locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,23 @@ You can pass more information using the command line:
 
     sigh resign ./path/app.ipa -i "iPhone Distribution: Felix Krause" -p "my.mobileprovision"
 
+# Manage
+
+If you simply want to manage your provisioning profiles locally, you can use `sigh manage`:
+
+
+    sigh manage
+
+`sigh` will find all installed provisioning profiles and list them in three categories: **active**, **expire within 30 days** and **expired**.
+
+To delete all expired provisioning profiles:
+
+    sigh manage -e
+
+Delete any non-wildcard `iOS Team Provisioning Profile`
+
+    sigh manage -p "iOS\ {0,1}Team Provisioning Profile: \w"
+
 ## Environment Variables
 In case you prefer environment variables:
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Delete all expired provisioning profiles
 
 Or delete all `iOS Team Provisioning Profile` by using a regular expression
 
-    sigh manage -p "iOS\ {0,1}Team Provisioning Profile:"
+    sigh manage -p "iOS\ ?Team Provisioning Profile:"
 
 ## Environment Variables
 In case you prefer environment variables:

--- a/README.md
+++ b/README.md
@@ -149,20 +149,17 @@ You can pass more information using the command line:
 
 # Manage
 
-If you simply want to manage your provisioning profiles locally, you can use `sigh manage`:
-
+With `sigh manage` you can list all provisioning profiles installed locally.
 
     sigh manage
 
-`sigh` will find all installed provisioning profiles and list them in three categories: **active**, **expire within 30 days** and **expired**.
-
-To delete all expired provisioning profiles:
+Delete all expired provisioning profiles
 
     sigh manage -e
 
-Delete any non-wildcard `iOS Team Provisioning Profile`
+Or delete all `iOS Team Provisioning Profile` by using a regular expression
 
-    sigh manage -p "iOS\ {0,1}Team Provisioning Profile: \w"
+    sigh manage -p "iOS\ {0,1}Team Provisioning Profile:"
 
 ## Environment Variables
 In case you prefer environment variables:

--- a/bin/sigh
+++ b/bin/sigh
@@ -52,10 +52,9 @@ class SighApplication
       c.description = 'Manage installed provisioning profiles on your system.'
       
       c.option '-e', '--clean_expired', 'Remove all expired provisioning profiles.'
-      c.example 'Remove non-wildcard iOS Team Provisioning e.g. "iOSTeam Provisioning Profile: *" survives and "iOSTeam Provisioning Profile: com.company.app" moves to .Trash', 'sigh manage -p "iOS\ {0,1}Team Provisioning Profile: \w"'
 
       c.option '-p', '--clean_pattern STRING', String, 'Remove any provisioning profiles that matches the pattern.'
-
+      c.example 'Remove non-wildcard iOS Team Provisioning e.g. "iOSTeam Provisioning Profile: *" survives and "iOSTeam Provisioning Profile: com.company.app" moves to .Trash', 'sigh manage -p "iOS\ {0,1}Team Provisioning Profile: \w"'
 
       c.action do |args, options|
         Sigh::Manager.new.run(options, args)

--- a/bin/sigh
+++ b/bin/sigh
@@ -54,7 +54,7 @@ class SighApplication
       c.option '-e', '--clean_expired', 'Remove all expired provisioning profiles.'
 
       c.option '-p', '--clean_pattern STRING', String, 'Remove any provisioning profiles that matches the regular expression.'
-      c.example 'Remove all "iOS Team Provisioning" provisioning profiles', 'sigh manage -p "iOS\ {0,1}Team Provisioning Profile"'
+      c.example 'Remove all "iOS Team Provisioning" provisioning profiles', 'sigh manage -p "iOS\ ?Team Provisioning Profile"'
 
       c.action do |args, options|
         Sigh::Manager.new.run(options, args)

--- a/bin/sigh
+++ b/bin/sigh
@@ -47,6 +47,21 @@ class SighApplication
       end
     end
 
+    command :manage do |c|
+      c.syntax = 'sigh manage'
+      c.description = 'Manage installed provisioning profiles on your system.'
+      
+      c.option '-e', '--clean_expired', 'Remove all expired provisioning profiles.'
+      c.example 'Remove non-wildcard iOS Team Provisioning e.g. "iOSTeam Provisioning Profile: *" survives and "iOSTeam Provisioning Profile: com.company.app" moves to .Trash', 'sigh manage -p "iOS\ {0,1}Team Provisioning Profile: \w"'
+
+      c.option '-p', '--clean_pattern STRING', String, 'Remove any provisioning profiles that matches the pattern.'
+
+
+      c.action do |args, options|
+        Sigh::Manager.new.run(options, args)
+      end
+    end
+
     default_command :renew
 
     run!

--- a/bin/sigh
+++ b/bin/sigh
@@ -53,8 +53,8 @@ class SighApplication
       
       c.option '-e', '--clean_expired', 'Remove all expired provisioning profiles.'
 
-      c.option '-p', '--clean_pattern STRING', String, 'Remove any provisioning profiles that matches the pattern.'
-      c.example 'Remove non-wildcard iOS Team Provisioning e.g. "iOSTeam Provisioning Profile: *" survives and "iOSTeam Provisioning Profile: com.company.app" moves to .Trash', 'sigh manage -p "iOS\ {0,1}Team Provisioning Profile: \w"'
+      c.option '-p', '--clean_pattern STRING', String, 'Remove any provisioning profiles that matches the regular expression.'
+      c.example 'Remove all "iOS Team Provisioning" provisioning profiles', 'sigh manage -p "iOS\ {0,1}Team Provisioning Profile"'
 
       c.action do |args, options|
         Sigh::Manager.new.run(options, args)

--- a/lib/sigh.rb
+++ b/lib/sigh.rb
@@ -2,6 +2,7 @@ require 'sigh/version'
 require 'sigh/dependency_checker'
 require 'sigh/developer_center'
 require 'sigh/resign'
+require 'sigh/manager'
 
 require 'fastlane_core'
 

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -1,5 +1,21 @@
+require 'plist'
+require 'fastlane_core'
+
 module Sigh
   class Manager
+    # Types of certificates
+    LIST = "list"
+    CLEANUP = "cleanup"
+
+    def run(options, args)
+      command, clean_expired, clean_pattern = get_inputs(options, args)
+      if command == LIST
+        list_profiles
+      elsif command == CLEANUP
+        cleanup_profiles(clean_expired, clean_pattern)
+      end
+    end
+
     def self.start
       path = Sigh::DeveloperCenter.new.run
 
@@ -35,6 +51,83 @@ module Sigh
       else
         raise "Failed installation of provisioning profile at location: #{destination}".red
       end
+    end
+
+    def get_inputs(options, args)
+      clean_expired = options.clean_expired
+      clean_pattern = /#{options.clean_pattern}/ if options.clean_pattern
+      command = (clean_expired != nil || clean_pattern != nil) ? CLEANUP : LIST
+      return command, clean_expired, clean_pattern
+    end
+
+    def list_profiles
+      profiles = load_profiles
+
+      now = DateTime.now
+      soon = (Date.today + 30).to_datetime
+
+      Helper.log.info "Provisioning profiles installed"
+      Helper.log.info "Valid:"
+      profiles_valid = profiles.select { |profile| profile["ExpirationDate"] > now && profile["ExpirationDate"] > soon }
+      profiles_valid.each do |profile|
+        Helper.log.info profile["Name"].green
+      end
+
+      Helper.log.info ""
+      Helper.log.info "Expiring within 30 day:"
+      profiles_soon = profiles.select { |profile| profile["ExpirationDate"] > now && profile["ExpirationDate"] < soon }
+      profiles_soon.each do |profile|
+        Helper.log.info profile["Name"].yellow
+      end      
+      
+      Helper.log.info ""
+      Helper.log.info "Expired:"
+      profiles_expired = profiles.select { |profile| profile["ExpirationDate"] < now }
+      profiles_expired.each do |profile|
+        Helper.log.info profile["Name"].red
+      end
+      
+      Helper.log.info ""
+      Helper.log.info "Summary"
+      Helper.log.info "#{profiles.length} installed profiles"
+      Helper.log.info "#{profiles_expired.length} are expired".red
+      Helper.log.info "#{profiles_soon.length} are valid but will expire within 30 days".yellow
+      Helper.log.info "#{profiles_valid.length} are valid".green
+    end
+
+    def cleanup_profiles(expired = false, pattern = nil)
+      now = DateTime.now
+
+      profiles = load_profiles.select { |profile| (expired && profile["ExpirationDate"] < now) || (pattern != nil && profile["Name"] =~ pattern) }
+
+      Helper.log.info "The following provisioning profiles are either expired or matches your pattern:"
+      profiles.each do |profile|
+        Helper.log.info profile["Name"].red
+      end
+
+      if agree("Delete these provisioning profiles #{profiles.length}? (y/n)  ", true)
+        Helper.log.info "Deleting #{profiles.length} profiles"
+        profiles.each do |profile|
+          File.delete profile["Path"]
+        end
+      end
+    end
+
+    def load_profiles
+      Helper.log.info "Loading Provisioning profiles from ~/Library/MobileDevice/Provisioning Profiles/"
+      profiles_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/*.mobileprovision"
+      profile_paths = Dir[profiles_path]
+
+      profiles = []
+      profile_paths.each do |profile_path|
+        profile = Plist::parse_xml(`security cms -D -i '#{profile_path}'`)
+        profile['Path'] = profile_path
+        profiles << profile
+      end
+
+      profiles = profiles.sort_by {|profile| profile["Name"].downcase}
+
+      return profiles
     end
   end
 end

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -1,5 +1,4 @@
 require 'plist'
-require 'fastlane_core'
 
 module Sigh
   class Manager


### PR DESCRIPTION
When you are added to 10+ iOS/OSX development teams and add those teams to Xcode you end up with a crazy amount of provisioning profiles. Currently I have 413 installed of which 124 are expired :disappointed:.

So I propose to add `sigh manage` for managing provisioning profiles locally.

Please bare with me since it is my first go at ruby :smile_cat: 
### Todo
- [x] Update README.md
- [x] `sigh manage` to list all installed provisioning profiles.
- [x] `sigh manage -e` to delete expired provisioning profiles.
- [x] `sigh manage -p PATTERN` to delete provisioning profiles matching a pattern.
- [ ] tests?
