### PR TITLE
Create install directory, if it doesn't exist

### DIFF
--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -27,6 +27,11 @@ module Sigh
       profile_filename = ENV["SIGH_UDID"] + ".mobileprovision"
       destination = profile_path + profile_filename
 
+      # If the directory doesn't exist, make it first
+      if !File.directory?(profile_path)
+        FileUtils.mkdir_p(profile_path)
+      end
+
       # copy to Xcode provisioning profile directory
       FileUtils.copy profile, destination
 

--- a/spec/developer_spec.rb
+++ b/spec/developer_spec.rb
@@ -4,6 +4,16 @@ describe "Create certificates" do
   regular_apple_id = "felix@sunapps.net"
   enterprise_apple_id = "felix.krause@sunapps.net"
 
+  profile_install_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles"
+  backup_profile_install_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles Old"
+
+  before :all do
+    # move existing folder to backup folder so we can test
+    if File.directory?(profile_install_path)
+      FileUtils.mv(profile_install_path, backup_profile_install_path)
+    end
+  end
+
   before :each do
     system("rm -rf /tmp/fastlane_core/")
   end
@@ -29,11 +39,30 @@ describe "Create certificates" do
     expect(File.exists?(File.join(path, "Distribution_net.sunapps.*.mobileprovision"))).to equal(true)
   end
 
+  it "Creates the install path if it does not exist yet" do
+    expect(File.directory?(profile_install_path)).to equal(false)
+
+    random_file_name = "test_#{Random.rand(1..10000000000000)}"
+    ENV["SIGH_UDID"] = random_file_name
+
+    file_name = "/tmp/#{random_file_name}.mobileprovision"
+    FileUtils.touch(file_name)
+
+    Sigh::Manager.install_profile(file_name)
+
+    expect(File.exists?(File.expand_path("~" + "/Library/MobileDevice/Provisioning Profiles/#{random_file_name}.mobileprovision"))).to equal(true)
+  end
+
   it "Installs the provisioning profile in the Xcode profile path" do
     # Enterprise
     ENV["DELIVER_USER"] = enterprise_apple_id
     install_path = "~/Library/MobileDevice/Provisioning Profiles/#{ENV["SIGH_UDID"]}.mobileprovision"
     Sigh::DeveloperCenter.new.run('net.sunapps.*', Sigh::DeveloperCenter::APPSTORE)
     expect(File.exists?(install_path)).to equal(true)
+  end
+
+  after :all do
+    FileUtils.remove_dir(profile_install_path)
+    File.rename(backup_profile_install_path, profile_install_path)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 
 require 'sigh'
+require 'sigh/manager'
 
 # This module is only used to check the environment is currently a testing env
 module SpecHelper


### PR DESCRIPTION
When using sigh to install provisioning profiles on a system that is
fresly installed with Xcode, it is entirely possible that the
provisioning profile directory has not been created yet.

If we attempt to simply copy the downloaded profile into that directory
when it does not exist, will cause a failure. Instead we should see if
the directory exists before copying into it. If it does not exist,
we create it, and continue the copy operation.
