### PR TITLE
Page through profiles on Developer Center

### DIFF
--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -91,15 +91,15 @@ module Sigh
 
               break
             end
+          end
 
-            if page_size == profile_count
-              page_index += 1
-            elsif
-              has_all_profiles = true
-            end
+          if page_size == profile_count
+            page_index += 1
+          else
+            has_all_profiles = true
           end
         end 
-        
+
         Helper.log.info "Could not find existing profile. Trying to create a new one."
         # Certificate does not exist yet, we need to create a new one
         create_profile

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -98,8 +98,8 @@ module Sigh
               has_all_profiles = true
             end
           end
-
         end 
+        
         Helper.log.info "Could not find existing profile. Trying to create a new one."
         # Certificate does not exist yet, we need to create a new one
         create_profile

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -48,44 +48,58 @@ module Sigh
         @list_certs_url = wait_for_variable('profileDataURL')
         # list_certs_url will look like this: "https://developer.apple.com/services-account/..../account/ios/profile/listProvisioningProfiles.action?content-type=application/x-www-form-urlencoded&accept=application/json&requestId=id&userLocale=en_US&teamId=xy&includeInactiveProfiles=true&onlyCountLists=true"
         Helper.log.info "Fetching all available provisioning profiles..."
+        
+        has_all_profiles = false
+        page_index = 1
+        page_size = 500
 
-        certs = post_ajax(@list_certs_url, "{pageNumber: 1, pageSize: 500, sort: 'name%3dasc'}")
+        until has_all_profiles do
+          certs = post_ajax(@list_certs_url, "{pageNumber: #{page_index}, pageSize: #{page_size}, sort: 'name%3dasc'}")
 
-        profile_name = Sigh.config[:provisioning_name]
+          profile_name = Sigh.config[:provisioning_name]
 
-        Helper.log.info "Checking if profile is available. (#{certs['provisioningProfiles'].count} profiles found)"
-        required_cert_types = (@type == DEVELOPMENT ? ['iOS Development'] : ['iOS Distribution', 'iOS UniversalDistribution'])
-        certs['provisioningProfiles'].each do |current_cert|
-          next unless required_cert_types.include?(current_cert['type'])
-          
-          details = profile_details(current_cert['provisioningProfileId'])
+          certificate_count = certs['provisioningProfiles'].count
 
-          if details['provisioningProfile']['appId']['identifier'] == Sigh.config[:app_identifier]
+          Helper.log.info "Checking if profile is available. (#{certificate_count} profiles found on page #{page_index})"
+          required_cert_types = (@type == DEVELOPMENT ? ['iOS Development'] : ['iOS Distribution', 'iOS UniversalDistribution'])
+          certs['provisioningProfiles'].each do |current_cert|
+            next unless required_cert_types.include?(current_cert['type'])
+            
+            details = profile_details(current_cert['provisioningProfileId'])
 
-            next if profile_name && details['provisioningProfile']['name'] != profile_name
+            if details['provisioningProfile']['appId']['identifier'] == Sigh.config[:app_identifier]
 
-            # that's an Ad Hoc profile. I didn't find a better way to detect if it's one ... skipping it
-            next if @type == APPSTORE && details['provisioningProfile']['deviceCount'] > 0
+              next if profile_name && details['provisioningProfile']['name'] != profile_name
 
-            # that's an App Store profile ... skipping it
-            next if @type != APPSTORE && details['provisioningProfile']['deviceCount'] == 0
+              # that's an Ad Hoc profile. I didn't find a better way to detect if it's one ... skipping it
+              next if @type == APPSTORE && details['provisioningProfile']['deviceCount'] > 0
 
-            # We found the correct certificate
-            if force && @type != DEVELOPMENT
-              provisioningProfileId = current_cert['provisioningProfileId']
-              renew_profile(provisioningProfileId) # This one needs to be forcefully renewed
-              return maintain_app_certificate(false) # recursive
-            elsif current_cert['status'] == 'Active'
-              return download_profile(details['provisioningProfile']['provisioningProfileId']) # this one is already finished. Just download it.
-            elsif ['Expired', 'Invalid'].include? current_cert['status']
-              renew_profile(current_cert['provisioningProfileId']) # This one needs to be renewed
-              return maintain_app_certificate(false) # recursive
+              # that's an App Store profile ... skipping it
+              next if @type != APPSTORE && details['provisioningProfile']['deviceCount'] == 0
+
+              # We found the correct certificate
+              if force && @type != DEVELOPMENT
+                provisioningProfileId = current_cert['provisioningProfileId']
+                renew_profile(provisioningProfileId) # This one needs to be forcefully renewed
+                return maintain_app_certificate(false) # recursive
+              elsif current_cert['status'] == 'Active'
+                return download_profile(details['provisioningProfile']['provisioningProfileId']) # this one is already finished. Just download it.
+              elsif ['Expired', 'Invalid'].include? current_cert['status']
+                renew_profile(current_cert['provisioningProfileId']) # This one needs to be renewed
+                return maintain_app_certificate(false) # recursive
+              end
+
+              break
             end
 
-            break
+            if page_size == certificate_count
+              page_index += 1
+            elsif
+              has_all_profiles = true
+            end
           end
-        end
 
+        end 
         Helper.log.info "Could not find existing profile. Trying to create a new one."
         # Certificate does not exist yet, we need to create a new one
         create_profile

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -98,7 +98,7 @@ module Sigh
           else
             has_all_profiles = true
           end
-        end 
+        end
 
         Helper.log.info "Could not find existing profile. Trying to create a new one."
         # Certificate does not exist yet, we need to create a new one

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -58,9 +58,9 @@ module Sigh
 
           profile_name = Sigh.config[:provisioning_name]
 
-          certificate_count = certs['provisioningProfiles'].count
+          profile_count = certs['provisioningProfiles'].count
 
-          Helper.log.info "Checking if profile is available. (#{certificate_count} profiles found on page #{page_index})"
+          Helper.log.info "Checking if profile is available. (#{profile_count} profiles found on page #{page_index})"
           required_cert_types = (@type == DEVELOPMENT ? ['iOS Development'] : ['iOS Distribution', 'iOS UniversalDistribution'])
           certs['provisioningProfiles'].each do |current_cert|
             next unless required_cert_types.include?(current_cert['type'])
@@ -92,7 +92,7 @@ module Sigh
               break
             end
 
-            if page_size == certificate_count
+            if page_size == profile_count
               page_index += 1
             elsif
               has_all_profiles = true


### PR DESCRIPTION
We currently have ~1900 provisioning profiles in our dev center and the latest change was only looking through one page and then trying to create one that already existed. This makes the change to page through each 500 at a time to find all the profiles before trying to create a new one.

![devcenter](https://cloud.githubusercontent.com/assets/1731082/7192464/8887621c-e45b-11e4-8c8a-fbe87d90308d.png)
