### PR TITLE
Use the Search API within the AJAX call

### DIFF
--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -58,7 +58,7 @@ module Sigh
 
           certs = post_ajax(@list_certs_url, "{pageNumber: #{page_index}, pageSize: #{page_size}, sort: 'name%3dasc', search: 'name%3D#{bundle_id}%26type%3D#{bundle_id}%26status%3D#{bundle_id}%26appId%3D#{bundle_id}'}")
 
-          unless certs
+          if certs
             profile_name = Sigh.config[:provisioning_name]
 
             profile_count = certs['provisioningProfiles'].count

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -95,7 +95,7 @@ module Sigh
             end
           end
 
-          if page_size == profile_count
+          if page_size <= profile_count
             page_index += 1
           else
             has_all_profiles = true

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -54,7 +54,9 @@ module Sigh
         page_size = 500
 
         until has_all_profiles do
-          certs = post_ajax(@list_certs_url, "{pageNumber: #{page_index}, pageSize: #{page_size}, sort: 'name%3dasc'}")
+          bundle_id = Sigh.config[:app_identifier]
+
+          certs = post_ajax(@list_certs_url, "{pageNumber: #{page_index}, pageSize: #{page_size}, sort: 'name%3dasc', search: 'name%3D#{bundle_id}%26type%3D#{bundle_id}%26status%3D#{bundle_id}%26appId%3D#{bundle_id}'}")
 
           profile_name = Sigh.config[:provisioning_name]
 
@@ -67,7 +69,7 @@ module Sigh
             
             details = profile_details(current_cert['provisioningProfileId'])
 
-            if details['provisioningProfile']['appId']['identifier'] == Sigh.config[:app_identifier]
+            if details['provisioningProfile']['appId']['identifier'] == bundle_id
 
               next if profile_name && details['provisioningProfile']['name'] != profile_name
 


### PR DESCRIPTION
Hey Felix,

Me again with our ~1900 profiles. Was thinking about this last night and have just run into issues where if you're on page 4 of the results it was taking upwards of 15 minutes to find a profile (not great at all). So I dug into some of the Apple requests and found their search API params so we can have the `bundle_id` passed into it to narrow the results. In my testing this brings down search times by a ton for us (<20 seconds now on one that was taking ~5 minutes) and figured it'd be helpful for others too. 

Successful: (This app was on page 2 previously, around the 800th one that I screenshotted in #80 )
![successful](https://cloud.githubusercontent.com/assets/1731082/7205056/2328edb4-e4ec-11e4-9576-d5461cfe4127.png)

I've run some minimal QA on it with a few of our bundle IDs and also passing in a bundle ID that doesn't exist in our dev center and it goes ahead and tries to create a new one. 
![no-bid](https://cloud.githubusercontent.com/assets/1731082/7205061/2d488e80-e4ec-11e4-9cc9-d065f3a6216e.png)

Might be worth running through some other potential use cases for this too. (But I can't think of any more right now)
