### PR TITLE
remove leftover debugger call

### DIFF
--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -70,7 +70,6 @@ module Sigh
 
             Helper.log.info "Checking if profile is available. (#{profile_count} profiles found on page #{page_index})"
             required_cert_types = (@type == DEVELOPMENT ? ['iOS Development'] : ['iOS Distribution', 'iOS UniversalDistribution'])
-            require 'pry'; binding.pry
             certs['provisioningProfiles'].each do |current_cert|
               next unless required_cert_types.include?(current_cert['type'])
               


### PR DESCRIPTION
I was testing out https://github.com/KrauseFx/sigh/pull/80 and https://github.com/KrauseFx/sigh/pull/82 in a local copy of this gem, and execution got tripped up by this call to `pry`. I'm assuming it's just leftover from a debugging session and that you don't want it in `master`...
