### PR TITLE
Updated README to clarify what SIGH_APP_IDENTIFER is

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Or delete all `iOS Team Provisioning Profile` by using a regular expression
 In case you prefer environment variables:
 
 - `SIGH_USERNAME`
-- `SIGH_APP_IDENTIFIER`
+- `SIGH_APP_IDENTIFIER` (The App's Bundle ID , e.g. `com.yourteam.awesomeapp`)
 - `SIGH_TEAM_ID` (The Team ID, e.g. `Q2CBPK58CA`)
 - `SIGH_PROVISIONING_PROFILE_NAME` (set a custom name for the name of the generated file)
 


### PR DESCRIPTION
Took me a couple of attempts to get the right value for `SIGH_APP_IDENTIFIER`. Wanted to make sure it was clear that it's asking for the bundle ID.
