### PR TITLE
Fix character encoding error when writing binary data (certificates)

### DIFF
--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -28,7 +28,9 @@ module Sigh
       cert_name += '.mobileprovision' unless cert_name.include?'mobileprovision'
 
       output_path = File.join(TMP_FOLDER, cert_name)
-      File.write(output_path, cert)
+      dataWritten = File.open(output_path, "wb") do |f|
+        f.write(cert)
+      end
 
       store_provisioning_id_in_environment(output_path)
 


### PR DESCRIPTION
Currently, files are written in non-binary mode, thus throwing an Encoding::UndefinedConversionError:

```
     Encoding::UndefinedConversionError:
       "\x82" from ASCII-8BIT to UTF-8
```

Fixes:
- Specify binary write mode (wb) when writing downloaded certificates to files in download_url method of developer_center.rb.
