### PR TITLE
Adds ability to renew all expired profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
   </a>
 </h3>
 <p align="center">
-  <a href="https://github.com/KrauseFx/deliver">deliver</a> &bull; 
-  <a href="https://github.com/KrauseFx/snapshot">snapshot</a> &bull; 
-  <a href="https://github.com/KrauseFx/frameit">frameit</a> &bull; 
-  <a href="https://github.com/KrauseFx/PEM">PEM</a> &bull; 
-  <b>sigh</b> &bull; 
+  <a href="https://github.com/KrauseFx/deliver">deliver</a> &bull;
+  <a href="https://github.com/KrauseFx/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/KrauseFx/frameit">frameit</a> &bull;
+  <a href="https://github.com/KrauseFx/PEM">PEM</a> &bull;
+  <b>sigh</b> &bull;
   <a href="https://github.com/KrauseFx/produce">produce</a> &bull;
   <a href="https://github.com/KrauseFx/cert">cert</a> &bull;
-  <a href="https://github.com/KrauseFx/codes">codes</a> 
+  <a href="https://github.com/KrauseFx/codes">codes</a>
 </p>
 -------
 
@@ -38,12 +38,12 @@ Special thanks to [Matthias Tretter](https://twitter.com/myell0w) for coming up 
 
 -------
 <p align="center">
-    <a href="#features">Features</a> &bull; 
-    <a href="#installation">Installation</a> &bull; 
-    <a href="#usage">Usage</a> &bull; 
-    <a href="#resign">Resign</a> &bull; 
-    <a href="#how-does-it-work">How does it work?</a> &bull; 
-    <a href="#tips">Tips</a> &bull; 
+    <a href="#features">Features</a> &bull;
+    <a href="#installation">Installation</a> &bull;
+    <a href="#usage">Usage</a> &bull;
+    <a href="#resign">Resign</a> &bull;
+    <a href="#how-does-it-work">How does it work?</a> &bull;
+    <a href="#tips">Tips</a> &bull;
     <a href="#need-help">Need help?</a>
 </p>
 
@@ -90,7 +90,7 @@ Make sure, you have the latest version of the Xcode command line tools installed
     sigh
 Yes, that's the whole command!
 
-```sigh``` will create, repair and download profiles for the App Store by default. 
+```sigh``` will create, repair and download profiles for the App Store by default.
 
 You can pass your bundle identifier and username like this:
 
@@ -99,25 +99,25 @@ You can pass your bundle identifier and username like this:
 If you want to generate an **Ad Hoc** profile instead of an App Store profile:
 
     sigh --adhoc
-    
+
 If you want to generate a **Development** profile:
 
     sigh --development
 
-To generate the profile in a specific directory: 
+To generate the profile in a specific directory:
 
     sigh -o "~/Certificates/"
 
 For a list of available commands run
 
     sigh --help
-    
+
 ### Advanced
 
 By default, ```sigh``` will install the downloaded profile on your machine. If you just want to generate the profile and skip the installation, use the following flag:
 
     sigh --skip_install
-    
+
 To save the provisioning profile under a specific name, use the -f option:
 
     sigh -a com.krausefx.app -u username -f "myProfile.mobileprovision"
@@ -133,6 +133,16 @@ By default, ```sigh``` will include all certificates on development profiles, an
 Or identify be expire date if you're using the same names for multiple certificates
 
     sigh -d "Nov 11, 2017"
+
+### Renewing all expired certificates
+
+Sigh can list out all expired profiles at the command line and even optionally renew all of the expired profiles in one command.
+
+    sigh expired
+
+By default `sigh` will only list the expired certificates.  If you want to renew each certificate, pass the `--renew` option.
+
+    sigh expired --renew
 
 # Resign
 
@@ -204,7 +214,7 @@ If you're using [cert](https://github.com/KrauseFx/cert) in combination with [fa
 ## Use the 'Provisioning Quicklook plugin'
 Download and install the [Provisioning Plugin](https://github.com/chockenberry/Provisioning).
 
-It will show you the ```mobileprovision``` files like this: 
+It will show you the ```mobileprovision``` files like this:
 ![assets/QuickLookScreenshot.png](assets/QuickLookScreenshot.png)
 
 

--- a/bin/sigh
+++ b/bin/sigh
@@ -37,6 +37,20 @@ class SighApplication
       end
     end
 
+    command :expired do |c|
+      c.syntax = 'sign expired'
+      c.description = 'Will list and optionally renew all expired profiles.'
+      c.option '-r', '--renew', String, 'Will perform renewal on each of the listed expired profiles'
+
+      c.action do |args, options|
+        global_options = options.__hash__.dup
+        global_options.delete(:renew)
+
+        Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, global_options)
+        Sigh::Manager.expired_profiles(options, args)
+      end
+    end
+
     command :resign do |c|
       c.syntax = 'sigh resign'
       c.description = 'Resigns an existing ipa file with the given provisioning profile'
@@ -51,7 +65,7 @@ class SighApplication
     command :manage do |c|
       c.syntax = 'sigh manage'
       c.description = 'Manage installed provisioning profiles on your system.'
-      
+
       c.option '-e', '--clean_expired', 'Remove all expired provisioning profiles.'
 
       c.option '-p', '--clean_pattern STRING', String, 'Remove any provisioning profiles that matches the regular expression.'

--- a/lib/sigh/developer_center.rb
+++ b/lib/sigh/developer_center.rb
@@ -9,14 +9,14 @@ module Sigh
     DEVELOPMENT = "Development"
 
     PROFILES_URL_DEV = "https://developer.apple.com/account/ios/profile/profileList.action?type=limited"
-    
+
     def run
       @type = Sigh::DeveloperCenter::APPSTORE
       @type = Sigh::DeveloperCenter::ADHOC if Sigh.config[:adhoc]
       @type = Sigh::DeveloperCenter::DEVELOPMENT if Sigh.config[:development]
 
       cert = maintain_app_certificate # create/download the certificate
-      
+
       if @type == APPSTORE # both enterprise and App Store
         type_name = "Distribution"
       elsif @type == ADHOC
@@ -43,10 +43,11 @@ module Sigh
       ENV["SIGH_UDID"] = udid if udid
     end
 
-    def maintain_app_certificate(force = nil)
-      force = Sigh.config[:force] if (force == nil)
+    def expired_profiles
+      required_cert_types = (@type == DEVELOPMENT ? ['iOS Development'] : ['iOS Distribution', 'iOS UniversalDistribution'])
+
       begin
-        if @type == DEVELOPMENT 
+        if @type == DEVELOPMENT
           visit PROFILES_URL_DEV
         else
           visit PROFILES_URL
@@ -55,7 +56,57 @@ module Sigh
         @list_certs_url = wait_for_variable('profileDataURL')
         # list_certs_url will look like this: "https://developer.apple.com/services-account/..../account/ios/profile/listProvisioningProfiles.action?content-type=application/x-www-form-urlencoded&accept=application/json&requestId=id&userLocale=en_US&teamId=xy&includeInactiveProfiles=true&onlyCountLists=true"
         Helper.log.info "Fetching all available provisioning profiles..."
-        
+
+        has_all_profiles = false
+        page_index = 1
+        page_size = 500
+        certificates = []
+
+        until has_all_profiles do
+          certs = post_ajax(@list_certs_url, "{pageNumber: #{page_index}, pageSize: #{page_size}, sort: 'name%3dasc', search: ''}")
+          if certs
+            profile_count = certs['provisioningProfiles'].count
+
+            Helper.log.info "Fetched #{ profile_count } profiles..."
+
+            certs['provisioningProfiles'].each do |current_cert|
+              next unless required_cert_types.include?(current_cert['type'])
+              next unless current_cert['status'] == 'Expired'
+
+              certificates << {
+                id: current_cert['provisioningProfileId'],
+                expired_on: current_cert['dateExpire'],
+                name: current_cert['name']
+              }
+            end
+
+            if page_size <= profile_count
+              page_index += 1
+            else
+              has_all_profiles = true
+            end
+          end
+        end
+
+        certificates
+      rescue => ex
+        error_occured(ex)
+      end
+    end
+
+    def maintain_app_certificate(force = nil)
+      force = Sigh.config[:force] if (force == nil)
+      begin
+        if @type == DEVELOPMENT
+          visit PROFILES_URL_DEV
+        else
+          visit PROFILES_URL
+        end
+
+        @list_certs_url = wait_for_variable('profileDataURL')
+        # list_certs_url will look like this: "https://developer.apple.com/services-account/..../account/ios/profile/listProvisioningProfiles.action?content-type=application/x-www-form-urlencoded&accept=application/json&requestId=id&userLocale=en_US&teamId=xy&includeInactiveProfiles=true&onlyCountLists=true"
+        Helper.log.info "Fetching all available provisioning profiles..."
+
         has_all_profiles = false
         page_index = 1
         page_size = 500
@@ -74,7 +125,7 @@ module Sigh
             required_cert_types = (@type == DEVELOPMENT ? ['iOS Development'] : ['iOS Distribution', 'iOS UniversalDistribution'])
             certs['provisioningProfiles'].each do |current_cert|
               next unless required_cert_types.include?(current_cert['type'])
-              
+
               details = profile_details(current_cert['provisioningProfileId'])
 
               if details['provisioningProfile']['appId']['identifier'] == bundle_id

--- a/lib/sigh/developer_center_signing.rb
+++ b/lib/sigh/developer_center_signing.rb
@@ -101,5 +101,9 @@ module Sigh
 
       raise "Could not find a Certificate#{predicates_str}. Please open #{current_url} and make sure you have a signing profile created, which matches the given filters".red
     end
+
+    def code_signing_certificate_for_renewal
+      @code_signing_certificate ||= code_signing_certificates(@type).first
+    end
   end
 end

--- a/lib/sigh/manager.rb
+++ b/lib/sigh/manager.rb
@@ -23,6 +23,14 @@ module Sigh
       return File.expand_path(output)
     end
 
+    def self.expired_profiles(options, args)
+      profiles = Sigh::DeveloperCenter.new.expired_profiles
+
+      profiles.each do |profile|
+        Helper.log.info "#{ profile[:name] } (#{ profile[:id] }) expired on #{ profile[:expired_on] }"
+      end
+    end
+
     def self.install_profile(profile)
       Helper.log.info "Installing provisioning profile..."
       profile_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"


### PR DESCRIPTION
Currently you would have to script renewing of expired profiles in your own system (my first attempt was in Rails with Sidekiq since I had the bundle identifiers) and calling the renew option each time, but it's very un-optimized.

Adds a new command line option to simply list all expired profiles, and optionally renew them if desired.  Does not respect or use the `skip_install` or `force` options, meaning it does not even download the profile, let alone install it, and `force` doesn't make sense since it was already expired.  This worked for my purposes where I didn't want 500 expired profiles downloaded anywhere, let alone installed, on the Mac running the command.

``` sh
# lists without renewing, lightening quick
sigh expired

# lists and then renews each one. caches the certificate so lookup is only performed once
sigh expired --renew
```
