### PR TITLE
Support to resign ipa with development profile

### DIFF
--- a/lib/sigh/resign.rb
+++ b/lib/sigh/resign.rb
@@ -33,7 +33,14 @@ module Sigh
       puts command.magenta
       output = `#{command}`
       puts output
-      if output.include?('Assuming Distribution Identity')
+
+      if signing_identity =~ /^iPhone Developer:*/
+        ptn = 'Assuming Development Identity'
+      else
+        ptn = 'Assuming Distribution Identity'
+      end
+
+      if output.include?(ptn)
         Helper.log.info "Successfully signed #{ipa}!".green
         true
       else


### PR DESCRIPTION
I would like to resign application(ipa file) with development profile, but resign.rb seems to support distribution profile only. This makes the change to support resign with development profile.
