### PR TITLE
Fixed issues with multiple profiles

### DIFF
--- a/lib/sigh/options.rb
+++ b/lib/sigh/options.rb
@@ -93,11 +93,6 @@ module Sigh
                                      description: "Skips the verification of existing profiles which is useful if you have thousands of profiles",
                                      is_string: false,
                                      default_value: false),
-        FastlaneCore::ConfigItem.new(key: :skip_name_verify,
-                                     env_name: "SIGH_SKIP_NAME_VERIFY",
-                                     description: "Skips the extra verification of the name which is useful if you have thousands of profiles",
-                                     is_string: false,
-                                     default_value: false),
       ]
     end
   end

--- a/lib/sigh/options.rb
+++ b/lib/sigh/options.rb
@@ -88,6 +88,11 @@ module Sigh
                                      verify_block: Proc.new do |value|
                                        raise "The output name must end with .mobileprovision".red unless value.end_with?".mobileprovision"
                                      end),
+        FastlaneCore::ConfigItem.new(key: :skip_fetch_profiles,
+                                     env_name: "SIGH_SKIP_FETCH_PROFILES",
+                                     description: "Skips the verification of existing profiles which is useful if you have thousands of profiles",
+                                     is_string: false,
+                                     default_value: false),
         FastlaneCore::ConfigItem.new(key: :skip_name_verify,
                                      env_name: "SIGH_SKIP_NAME_VERIFY",
                                      description: "Skips the extra verification of the name which is useful if you have thousands of profiles",

--- a/lib/sigh/spaceship/runner.rb
+++ b/lib/sigh/spaceship/runner.rb
@@ -66,7 +66,6 @@ module Sigh
 
     # Create a new profile and return it
     def create_profile!
-      Helper.log.info "Creating profile..."
       cert = certificate_to_use
       bundle_id = Sigh.config[:app_identifier]
       name = Sigh.config[:provisioning_name] || [bundle_id, profile_type.pretty_type].join(' ')

--- a/lib/sigh/spaceship/runner.rb
+++ b/lib/sigh/spaceship/runner.rb
@@ -70,7 +70,7 @@ module Sigh
       bundle_id = Sigh.config[:app_identifier]
       name = Sigh.config[:provisioning_name] || [bundle_id, profile_type.pretty_type].join(' ')
 
-      unless Sigh.config[:skip_name_verify]
+      unless Sigh.config[:skip_fetch_profiles]
         if Spaceship.provisioning_profile.all.find { |p| p.name == name }
           Helper.log.error "The name '#{name}' is already taken, using another one."
           name += " #{Time.now.to_i}"

--- a/lib/sigh/spaceship/runner.rb
+++ b/lib/sigh/spaceship/runner.rb
@@ -61,6 +61,7 @@ module Sigh
 
     # Create a new profile and return it
     def create_profile!
+      Helper.log.info "Creating profile..."
       cert = certificate_to_use
       bundle_id = Sigh.config[:app_identifier]
       name = Sigh.config[:provisioning_name] || [bundle_id, profile_type.pretty_type].join(' ')

--- a/lib/sigh/spaceship/runner.rb
+++ b/lib/sigh/spaceship/runner.rb
@@ -12,24 +12,29 @@ module Sigh
       Spaceship.select_team
       Helper.log.info "Successfully logged in"
 
-      profiles = fetch_profiles # download the profile if it's there
+      unless Sigh.config[:skip_fetch_profiles]
+        profiles = fetch_profiles # download the profile if it's there
 
-      if profiles.count > 0
-        Helper.log.info "Found #{profiles.count} matching profile(s)".yellow
-        profile = profiles.first
+        if profiles.count > 0
+          Helper.log.info "Found #{profiles.count} matching profile(s)".yellow
+          profile = profiles.first
 
-        if Sigh.config[:force]
-          unless profile_type == Spaceship.provisioning_profile::AppStore
-            Helper.log.info "Updating the profile to include all devices".yellow
-            profile.devices = Spaceship.device.all
-          else
-            Helper.log.info "Updating the provisioning profile".yellow
+          if Sigh.config[:force]
+            unless profile_type == Spaceship.provisioning_profile::AppStore
+              Helper.log.info "Updating the profile to include all devices".yellow
+              profile.devices = Spaceship.device.all
+            else
+              Helper.log.info "Updating the provisioning profile".yellow
+            end
+
+            profile = profile.update! # assign it, as it's a new profile
           end
-
-          profile = profile.update! # assign it, as it's a new profile
+        else
+          Helper.log.info "No existing profiles found, creating a new one for you".yellow
+          profile = create_profile!
         end
       else
-        Helper.log.info "No existing profiles found, creating a new one for you".yellow
+        Helper.log.info "Not checking for existing profiles, creating a new one for you".yellow
         profile = create_profile!
       end
 

--- a/lib/sigh/spaceship/runner.rb
+++ b/lib/sigh/spaceship/runner.rb
@@ -55,6 +55,7 @@ module Sigh
 
     # Fetches a profile matching the user's search requirements
     def fetch_profiles
+      Helper.log.info "Fetching profiles..."
       profile_type.find_by_bundle_id(Sigh.config[:app_identifier]).find_all { |a| a.valid? }
     end
 


### PR DESCRIPTION
When you have a lot of provisioning profiles, spaceship times out when it tries to fetch them
(Spaceship.provisioning_profile.all, Spaceship.provisioning_profile.app_store.all, Spaceship.provisioning_profile.ad_hoc.all, Spaceship.provisioning_profile.development.all, Spaceship.provisioning_profile.app_store.find_by_bundle_id("com.krausefx.app"))

I've added a new option skip_fetch_profiles which sould be used along with skip_name_verify to avoid timeouts with multiple profiles. 
This could be only one option, but I didn't know if you wanted to keep thing more tidy and have different names reflecting what will do each option
