### PR TITLE
enable developement and adhoc options in case of Enterprise account

### DIFF
--- a/lib/sigh/spaceship/runner.rb
+++ b/lib/sigh/spaceship/runner.rb
@@ -44,9 +44,9 @@ module Sigh
       return @profile_type if @profile_type
 
       @profile_type = Spaceship.provisioning_profile.app_store
+      @profile_type = Spaceship.provisioning_profile.in_house if Spaceship.client.in_house?
       @profile_type = Spaceship.provisioning_profile.ad_hoc if Sigh.config[:adhoc]
       @profile_type = Spaceship.provisioning_profile.development if Sigh.config[:development]
-      @profile_type = Spaceship.provisioning_profile.in_house if Spaceship.client.in_house?
 
       @profile_type
     end


### PR DESCRIPTION
I'd like to download development or adhoc provisioning profiles while using Enterprise Developer Account. So far, it's not possible, because adhoc / development flags are not taken into account in case of InHouse account. My fix should make it work properly.
