### PR TITLE
Nested resigning

### DIFF
--- a/bin/sigh
+++ b/bin/sigh
@@ -61,6 +61,7 @@ class SighApplication
       c.description = 'Resigns an existing ipa file with the given provisioning profile'
       c.option '-i', '--signing_identity STRING', String, 'The signing identity to use. Must match the one defined in the provisioning profile.'
       c.option '-p', '--provisioning_profile STRING', String, 'The path to the provisioning profile which should be used'
+      c.option '-P', '--provisioning_profiles BUNDLE_ID,PATH,BUNDLE_ID,PATH', Array, 'A list of bundle identifiers and the paths to the related provisioning profile'
 
       c.action do |args, options|
         Sigh::Resign.new.run(options, args)

--- a/bin/sigh
+++ b/bin/sigh
@@ -61,9 +61,9 @@ class SighApplication
       c.description = 'Resigns an existing ipa file with the given provisioning profile'
       c.option '-i', '--signing_identity STRING', String, 'The signing identity to use. Must match the one defined in the provisioning profile.'
       c.option '-p', '--provisioning_profile PATH', String, '(or BUNDLE_ID=PATH) The path to the provisioning profile which should be used.'\
-        'Can be provided multiple times if the application contains nested applications and app extensions, which need their own provisioning profile.'\
-        'The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.',
-        &multiple_values_option_proc(c, "provisioning_profile", &proc { |value| value.split('=', 2) })
+               'Can be provided multiple times if the application contains nested applications and app extensions, which need their own provisioning profile.'\
+               'The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.',
+               &multiple_values_option_proc(c, "provisioning_profile", &proc { |value| value.split('=', 2) })
 
       c.action do |args, options|
         Sigh::Resign.new.run(options, args)
@@ -92,7 +92,7 @@ class SighApplication
   def multiple_values_option_proc(command, name)
     proc do |value|
       value = yield(value) if block_given?
-      option = command.proxy_options.find { |option| option[0] == name } || []
+      option = command.proxy_options.find { |opt| opt[0] == name } || []
       values = option[1] || []
       values << value
 

--- a/bin/sigh
+++ b/bin/sigh
@@ -60,16 +60,15 @@ class SighApplication
       c.syntax = 'sigh resign'
       c.description = 'Resigns an existing ipa file with the given provisioning profile'
       c.option '-i', '--signing_identity STRING', String, 'The signing identity to use. Must match the one defined in the provisioning profile.'
-      c.option '-p', '--provisioning_profile STRING', String, 'The path to the provisioning profile which should be used'
-      c.option '-P', '--provisioning_profiles BUNDLE_ID,PATH', Array, 'A pair of bundle identifier and the path to the related provisioning profile. Can be provided multiple times.' do |value|
-        provisioning_profiles_option = c.proxy_options.find { |option| option[0] == "provisioning_profiles"} || []
-        provisioning_profiles = provisioning_profiles_option[1] || {}
-        provisioning_profiles[value[0]] = value[1]
+      c.option '-p', '--provisioning_profile PATH', String, '(or BUNDLE_ID=PATH) The path to the provisioning profile which should be used. Can be provided multiple times if the application contains nested applications and app extensions, which need their own provisioning profile. The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.' do |value|
+        provisioning_profiles_option = c.proxy_options.find { |option| option[0] == "provisioning_profile" } || []
+        provisioning_profiles = provisioning_profiles_option[1] || []
+        provisioning_profiles << value.split('=', 2)
 
         c.proxy_options.delete provisioning_profiles_option
-        c.proxy_options << ["provisioning_profiles", provisioning_profiles]
+        c.proxy_options << ["provisioning_profile", provisioning_profiles]
       end
-      
+
       c.action do |args, options|
         Sigh::Resign.new.run(options, args)
       end

--- a/bin/sigh
+++ b/bin/sigh
@@ -61,8 +61,15 @@ class SighApplication
       c.description = 'Resigns an existing ipa file with the given provisioning profile'
       c.option '-i', '--signing_identity STRING', String, 'The signing identity to use. Must match the one defined in the provisioning profile.'
       c.option '-p', '--provisioning_profile STRING', String, 'The path to the provisioning profile which should be used'
-      c.option '-P', '--provisioning_profiles BUNDLE_ID,PATH,BUNDLE_ID,PATH', Array, 'A list of bundle identifiers and the paths to the related provisioning profile'
+      c.option '-P', '--provisioning_profiles BUNDLE_ID,PATH', Array, 'A pair of bundle identifier and the path to the related provisioning profile. Can be provided multiple times.' do |value|
+        provisioning_profiles_option = c.proxy_options.find { |option| option[0] == "provisioning_profiles"} || []
+        provisioning_profiles = provisioning_profiles_option[1] || {}
+        provisioning_profiles[value[0]] = value[1]
 
+        c.proxy_options.delete provisioning_profiles_option
+        c.proxy_options << ["provisioning_profiles", provisioning_profiles]
+      end
+      
       c.action do |args, options|
         Sigh::Resign.new.run(options, args)
       end

--- a/bin/sigh
+++ b/bin/sigh
@@ -60,14 +60,10 @@ class SighApplication
       c.syntax = 'sigh resign'
       c.description = 'Resigns an existing ipa file with the given provisioning profile'
       c.option '-i', '--signing_identity STRING', String, 'The signing identity to use. Must match the one defined in the provisioning profile.'
-      c.option '-p', '--provisioning_profile PATH', String, '(or BUNDLE_ID=PATH) The path to the provisioning profile which should be used. Can be provided multiple times if the application contains nested applications and app extensions, which need their own provisioning profile. The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.' do |value|
-        provisioning_profiles_option = c.proxy_options.find { |option| option[0] == "provisioning_profile" } || []
-        provisioning_profiles = provisioning_profiles_option[1] || []
-        provisioning_profiles << value.split('=', 2)
-
-        c.proxy_options.delete provisioning_profiles_option
-        c.proxy_options << ["provisioning_profile", provisioning_profiles]
-      end
+      c.option '-p', '--provisioning_profile PATH', String, '(or BUNDLE_ID=PATH) The path to the provisioning profile which should be used.'\
+        'Can be provided multiple times if the application contains nested applications and app extensions, which need their own provisioning profile.'\
+        'The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.',
+        &multiple_values_option_proc(c, "provisioning_profile", &proc { |value| value.split('=', 2) })
 
       c.action do |args, options|
         Sigh::Resign.new.run(options, args)
@@ -91,6 +87,18 @@ class SighApplication
     default_command :renew
 
     run!
+  end
+
+  def multiple_values_option_proc(command, name)
+    proc do |value|
+      value = yield(value) if block_given?
+      option = command.proxy_options.find { |option| option[0] == name } || []
+      values = option[1] || []
+      values << value
+
+      command.proxy_options.delete option
+      command.proxy_options << [name, values]
+    end
   end
 end
 

--- a/lib/assets/resign.sh
+++ b/lib/assets/resign.sh
@@ -357,7 +357,6 @@ then
 fi
 
 
-# Resign the application
 if [ "$ENTITLEMENTS" != "" ];
 then
     if [ -n "$APP_IDENTIFER_PREFIX" ];
@@ -491,8 +490,9 @@ rm -f "$TEMP_DIR/profile.plist"
 while IFS= read -d '' -r app;
 do
     resign "$app" YES
-done < <(find "$TEMP_DIR/Payload/$APP_NAME" -d \( -name "*.app" -or -name "*.appex" \) -print0)
+done < <(find "$TEMP_DIR/Payload/$APP_NAME" -d -mindepth 1 \( -name "*.app" -or -name "*.appex" \) -print0)
 
+# Resign the application
 resign "$TEMP_DIR/Payload/$APP_NAME" NO
 
 # Repackage quietly

--- a/lib/assets/resign.sh
+++ b/lib/assets/resign.sh
@@ -33,7 +33,7 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 # Please let us know about any improvements you make to this script!
-# ./floatsign source "iPhone Distribution: Name" -p "path/to/profile" [-d "display name"]  [-e entitlements] [-k keychain] -b "BundleIdentifier" outputIpa
+# ./floatsign source "iPhone Distribution: Name" -p "path/to/profile" [-d "display name"]  [-e entitlements] [-k keychain] [-b "BundleIdentifier"] outputIpa
 #
 #
 # Modifed 26th January 2012
@@ -54,6 +54,8 @@
 # 
 # new features October 2015
 # 1. now re-signs nested applications and app extensions, if present, prior to re-signing the application itself
+# 2. enables the -p option to be used more than once
+# 2. ensures the provisioning profile's bundle-identifier matches the app's bundle identifier
 #
 
 
@@ -67,9 +69,8 @@ fi
 }
 
 if [ $# -lt 3 ]; then
-    echo "usage: $0 source identity -p provisioning [-e entitlements] [-r adjustBetaReports] [-d displayName] [-n version] [-m srcBundleId=provisioning] -b bundleId outputIpa" >&2
-    echo "       -p and -b are optional, but their use is heavly recommended" >&2
-    echo "       -m option may be provided multiple times" >&2
+    echo "usage: $0 source identity -p provisioning [-e entitlements] [-r adjustBetaReports] [-d displayName] [-n version] [-b bundleId] outputIpa" >&2
+    echo "       -p option may be provided multiple times" >&2
     echo "       -r flag requires a value '-r yes'" >&2
     echo "       -r flag is ignored if -e is also used" >&2
     exit 1
@@ -77,23 +78,28 @@ fi
 
 ORIGINAL_FILE="$1"
 CERTIFICATE="$2"
-NEW_PROVISION=
 ENTITLEMENTS=
 BUNDLE_IDENTIFIER=""
 DISPLAY_NAME=""
 KEYCHAIN=""
 VERSION_NUMBER=""
 ADJUST_BETA_REPORTS_ACTIVE_FLAG="0"
+RAW_PROVISIONS=()
 PROVISIONS_BY_ID=()
+DEFAULT_PROVISION=""
 TEMP_DIR="_floatsignTemp"
 
 # options start index
 OPTIND=3
-while getopts p:d:e:k:b:r:n:m: opt; do
+while getopts p:d:e:k:b:r:n: opt; do
     case $opt in
         p)
-            NEW_PROVISION="$OPTARG"
-            echo "Specified provisioning profile: '$NEW_PROVISION'" >&2
+            RAW_PROVISIONS+=("$OPTARG")
+            if [[ "$OPTARG" =~ .+=.+ ]]; then
+                echo "Specified provisioning profile: '${OPTARG#*=}' for bundle identifier: '${OPTARG%%=*}'" >&2
+            else
+                echo "Specified provisioning profile: '$OPTARG'" >&2
+            fi
             ;;
         d)
             DISPLAY_NAME="$OPTARG"
@@ -119,14 +125,6 @@ while getopts p:d:e:k:b:r:n:m: opt; do
             ADJUST_BETA_REPORTS_ACTIVE_FLAG="1"
             echo "Enabled adjustment of beta-reports-active entitlements" >&2
             ;;
-        m)
-            if [[ ! "$OPTARG" =~ ^.+=.+$ ]]; then
-                echo "Invalid value '$OPTARG' for option -m" >&2
-                exit 1
-            fi
-            PROVISIONS_BY_ID+=("$OPTARG")
-            echo "Specified provisioning profile: '${OPTARG#*=}' for bundle identifier: '${OPTARG%%=*}'" >&2
-            ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
             exit 1
@@ -147,6 +145,10 @@ then
     exit 1
 fi
 
+if [[ "${#RAW_PROVISIONS[*]}" == "0" ]]; then
+    echo "-p 'xxxx.mobileprovision' argument is required" >&2
+    exit 1;
+fi
 
 # Check for and remove the temporary directory if it already exists
 if [ -d "$TEMP_DIR" ]; 
@@ -191,6 +193,85 @@ APP_NAME=$(ls "$TEMP_DIR/Payload/")
 # Make sure that PATH includes the location of the PlistBuddy helper tool as its location is not standard
 export PATH=$PATH:/usr/libexec
 
+# Test whether two bundle identifiers match
+# The first one may contain the wildcard character '*', in which case pattern matching will be used unless the third parameter is "STRICT"
+function does_bundle_id_match {
+
+if [[ "$1" == "$2" ]]; then
+    return 0
+elif [[ "$3" != STRICT && "$1" =~ \* ]]; then
+    local PATTERN0="${1//\./\\.}"       # com.example.*     -> com\.example\.*
+    local PATTERN1="${PATTERN0//\*/.*}" # com\.example\.*   -> com\.example\..*
+    if [[ "$2" =~ ^$PATTERN1$ ]]; then
+        return 0
+    fi
+fi
+
+return 1
+}
+
+# Find the provisioning profile for a given bundle identifier
+function provision_for_bundle_id {
+
+for ARG in "${PROVISIONS_BY_ID[@]}"; do
+    if does_bundle_id_match "${ARG%%=*}" "$1" "$2"; then
+        echo "${ARG#*=}"
+        break
+    fi
+done
+}
+
+# Find the bundle identifier contained inside a provisioning profile
+function bundle_id_for_provison {
+
+local FULL_BUNDLE_ID=`PlistBuddy -c 'Print :Entitlements:application-identifier' /dev/stdin <<< $(security cms -D -i "$1")`
+checkStatus
+echo "${FULL_BUNDLE_ID#*.}"
+}
+
+# Add given provisioning profile and bundle identifier to the search list
+function add_provision_for_bundle_id {
+
+local PROVISION="$1"
+local BUNDLE_ID="$2"
+
+local CURRENT_PROVISION=`provision_for_bundle_id "$BUNDLE_ID" STRICT`
+
+if [[ "$CURRENT_PROVISION" != "" && "$CURRENT_PROVISION" != "$PROVISION" ]]; then
+    echo "Conflicting provisioning profiles '$PROVISION' and '$CURRENT_PROVISION' for bundle identifier '$BUNDLE_ID'." >&2
+    exit 1
+fi
+
+PROVISIONS_BY_ID+=("$BUNDLE_ID=$PROVISION")
+}
+
+# Add given provisioning profile to the search list
+function add_provision {
+
+local PROVISION="$1"
+
+if [[ "$1" =~ .+=.+ ]]; then
+    PROVISION="${1#*=}"
+    add_provision_for_bundle_id "$PROVISION" "${1%%=*}"
+elif [[ "$DEFAULT_PROVISION" == "" ]]; then
+    DEFAULT_PROVISION="$PROVISION"
+fi
+
+if [[ ! -e "$PROVISION" ]]; then
+    echo "Provisioning profile '$PROVISION' file does not exist" >&2
+    exit 1;
+fi
+
+local BUNDLE_ID=`bundle_id_for_provison "$PROVISION"`
+add_provision_for_bundle_id "$PROVISION" "$BUNDLE_ID"
+}
+
+# Load bundle identifiers from provisioning profiles
+for ARG in "${RAW_PROVISIONS[@]}"; do
+    add_provision "$ARG"
+done
+
+# Resign the given application
 function resign {
 
 local APP_PATH="$1"
@@ -200,10 +281,9 @@ local NEW_PROVISION="$NEW_PROVISION"
 local APP_IDENTIFER_PREFIX=""
 local TEAM_IDENTIFIER=""
 
-if [[ "$NESTED" == YES ]]; then
-    # Ignore bundle identifier and provision arguments for nested applications
+if [[ "$NESTED" == NESTED ]]; then
+    # Ignore bundle identifier for nested applications
     BUNDLE_IDENTIFIER=""
-    NEW_PROVISION=""
 fi
 
 # Make sure that the Info.plist file is where we expect it
@@ -216,39 +296,37 @@ fi
 # Read in current values from the app
 local CURRENT_NAME=`PlistBuddy -c "Print :CFBundleDisplayName" "$APP_PATH/Info.plist"`
 local CURRENT_BUNDLE_IDENTIFIER=`PlistBuddy -c "Print :CFBundleIdentifier" "$APP_PATH/Info.plist"`
+local NEW_PROVISION=`provision_for_bundle_id "${BUNDLE_IDENTIFIER:-$CURRENT_BUNDLE_IDENTIFIER}"`
 
-# Choose a provisioning profile for the app
-if [[ "${#PROVISIONS_BY_ID[@]}" -gt 0 ]];
-then
-    for ARG in "${PROVISIONS_BY_ID[@]}";
-    do
-        if [[ "${ARG%%=*}" == "$CURRENT_BUNDLE_IDENTIFIER" ]];
-        then
-            NEW_PROVISION="${ARG#*=}"
-            # We could break but continuing allow later arguments to override previous ones
-        fi
-    done
-    if [[ "$NEW_PROVISION" == "" ]];
-    then
-        echo "No provisioning profile for application: '$APP_PATH' with bundle identifier '$CURRENT_BUNDLE_IDENTIFIER'" >&2
-        echo "Use the -m option (example: -m $CURRENT_BUNDLE_IDENTIFIER=xxxx.mobileprovision)" >&2
-        exit 1;
+if [[ "$NEW_PROVISION" == "" && "$NESTED" != NESTED ]]; then
+    NEW_PROVISION="$DEFAULT_PROVISION"
+fi
+
+if [[ "$NEW_PROVISION" == "" ]]; then
+    if [[ "$NESTED" == NESTED ]]; then
+        echo "No provisioning profile for nested application: '$APP_PATH' with bundle identifier '${BUNDLE_IDENTIFIER:-$CURRENT_BUNDLE_IDENTIFIER}'" >&2
+    else
+        echo "No provisioning profile for application: '$APP_PATH' with bundle identifier '${BUNDLE_IDENTIFIER:-$CURRENT_BUNDLE_IDENTIFIER}'" >&2
     fi
-elif [[ "$NESTED" == YES ]];
-then
-    echo "No provisioning profile for nested application: '$APP_PATH'" >&2
-    echo "Use the -m option (example: -m com.example.app=xxxx.mobileprovision)" >&2
+    echo "Use the -p option (example: -p com.example.app=xxxx.mobileprovision)" >&2
     exit 1;
 fi
 
-if [ "${BUNDLE_IDENTIFIER}" == "" ];
-then
-    BUNDLE_IDENTIFIER=`egrep -a -A 2 application-identifier "${NEW_PROVISION}" | grep string | sed -e 's/<string>//' -e 's/<\/string>//' -e 's/ //' | awk '{split($0,a,"."); i = length(a); for(ix=2; ix <= i;ix++){ s=s a[ix]; if(i!=ix){s=s "."};} print s;}'`
-    if [[ "${BUNDLE_IDENTIFIER}" == *\** ]]; then
+local PROVISION_BUNDLE_IDENTIFIER=`bundle_id_for_provison "$NEW_PROVISION"`
+
+# Use provisioning profile's bundle identifier
+if [ "$BUNDLE_IDENTIFIER" == "" ]; then
+    if [[ "$PROVISION_BUNDLE_IDENTIFIER" =~ \* ]]; then
         echo "Bundle Identifier contains a *, using the current bundle identifier" >&2
-        BUNDLE_IDENTIFIER=$CURRENT_BUNDLE_IDENTIFIER;
+        BUNDLE_IDENTIFIER="$CURRENT_BUNDLE_IDENTIFIER"
+    else
+        BUNDLE_IDENTIFIER="$PROVISION_BUNDLE_IDENTIFIER"
     fi
-    checkStatus
+fi
+
+if ! does_bundle_id_match "$PROVISION_BUNDLE_IDENTIFIER" "$BUNDLE_IDENTIFIER"; then
+    echo "Bundle Identifier '$PROVISION_BUNDLE_IDENTIFIER' in provisioning profile '$NEW_PROVISION' does not match the Bundle Identifier '$BUNDLE_IDENTIFIER' for application '$APP_PATH'." >&2
+    exit 1
 fi
 
 echo "Current bundle identifier is: '$CURRENT_BUNDLE_IDENTIFIER'" >&2
@@ -265,52 +343,40 @@ then
 fi
 
 # Replace the embedded mobile provisioning profile
-if [ "$NEW_PROVISION" != "" ];
+echo "Validating the new provisioning profile: $NEW_PROVISION" >&2
+security cms -D -i "$NEW_PROVISION" > "$TEMP_DIR/profile.plist"
+checkStatus
+
+APP_IDENTIFER_PREFIX=`PlistBuddy -c "Print :Entitlements:application-identifier" "$TEMP_DIR/profile.plist" | grep -E '^[A-Z0-9]*' -o | tr -d '\n'` 
+if [ "$APP_IDENTIFER_PREFIX" == "" ];
 then
-    if [[ -e "$NEW_PROVISION" ]];
+    APP_IDENTIFER_PREFIX=`PlistBuddy -c "Print :ApplicationIdentifierPrefix:0" "$TEMP_DIR/profile.plist"` 
+    if [ "$APP_IDENTIFER_PREFIX" == "" ];
     then
-        echo "Validating the new provisioning profile: $NEW_PROVISION" >&2
-        security cms -D -i "$NEW_PROVISION" > "$TEMP_DIR/profile.plist"
-        checkStatus
-
-        APP_IDENTIFER_PREFIX=`PlistBuddy -c "Print :Entitlements:application-identifier" "$TEMP_DIR/profile.plist" | grep -E '^[A-Z0-9]*' -o | tr -d '\n'` 
-        if [ "$APP_IDENTIFER_PREFIX" == "" ];
-        then
-            APP_IDENTIFER_PREFIX=`PlistBuddy -c "Print :ApplicationIdentifierPrefix:0" "$TEMP_DIR/profile.plist"` 
-            if [ "$APP_IDENTIFER_PREFIX" == "" ];
-            then
-                echo "Failed to extract any app identifier prefix from '$NEW_PROVISION'" >&2
-                exit 1;
-            else
-                echo "WARNING: extracted an app identifier prefix '$APP_IDENTIFER_PREFIX' from '$NEW_PROVISION', but it was not found in the profile's entitlements" >&2
-            fi
-        else
-            echo "Profile app identifier prefix is '$APP_IDENTIFER_PREFIX'" >&2
-        fi
-        
-        TEAM_IDENTIFIER=`PlistBuddy -c "Print :Entitlements:com.apple.developer.team-identifier" "$TEMP_DIR/profile.plist" | tr -d '\n'` 
-        if [ "$TEAM_IDENTIFIER" == "" ];
-        then
-            TEAM_IDENTIFIER=`PlistBuddy -c "Print :TeamIdentifier:0" "$TEMP_DIR/profile.plist"` 
-            if [ "$TEAM_IDENTIFIER" == "" ];
-            then
-                echo "Failed to extract team identifier from '$NEW_PROVISION', resigned ipa may fail on iOS 8 and higher" >&2
-            else
-                echo "WARNING: extracted a team identifier '$TEAM_IDENTIFIER' from '$NEW_PROVISION', but it was not found in the profile's entitlements, resigned ipa may fail on iOS 8 and higher" >&2
-            fi
-        else
-            echo "Profile team identifier is '$TEAM_IDENTIFIER'" >&2
-        fi
-
-        cp "$NEW_PROVISION" "$APP_PATH/embedded.mobileprovision"
-    else
-        echo "Provisioning profile '$NEW_PROVISION' file does not exist" >&2
+        echo "Failed to extract any app identifier prefix from '$NEW_PROVISION'" >&2
         exit 1;
+    else
+        echo "WARNING: extracted an app identifier prefix '$APP_IDENTIFER_PREFIX' from '$NEW_PROVISION', but it was not found in the profile's entitlements" >&2
     fi
 else
-    echo "-p 'xxxx.mobileprovision' argument is required" >&2
-    exit 1;
+    echo "Profile app identifier prefix is '$APP_IDENTIFER_PREFIX'" >&2
 fi
+
+TEAM_IDENTIFIER=`PlistBuddy -c "Print :Entitlements:com.apple.developer.team-identifier" "$TEMP_DIR/profile.plist" | tr -d '\n'` 
+if [ "$TEAM_IDENTIFIER" == "" ];
+then
+    TEAM_IDENTIFIER=`PlistBuddy -c "Print :TeamIdentifier:0" "$TEMP_DIR/profile.plist"` 
+    if [ "$TEAM_IDENTIFIER" == "" ];
+    then
+        echo "Failed to extract team identifier from '$NEW_PROVISION', resigned ipa may fail on iOS 8 and higher" >&2
+    else
+        echo "WARNING: extracted a team identifier '$TEAM_IDENTIFIER' from '$NEW_PROVISION', but it was not found in the profile's entitlements, resigned ipa may fail on iOS 8 and higher" >&2
+    fi
+else
+    echo "Profile team identifier is '$TEAM_IDENTIFIER'" >&2
+fi
+
+cp "$NEW_PROVISION" "$APP_PATH/embedded.mobileprovision"
 
 
 #if the current bundle identifier is different from the new one in the provisioning profile, then change it.
@@ -489,11 +555,12 @@ rm -f "$TEMP_DIR/profile.plist"
 # Sign nested applications and app extensions
 while IFS= read -d '' -r app;
 do
-    resign "$app" YES
+    echo "Resigning nested application: '$app'" >&2
+    resign "$app" NESTED
 done < <(find "$TEMP_DIR/Payload/$APP_NAME" -d -mindepth 1 \( -name "*.app" -or -name "*.appex" \) -print0)
 
 # Resign the application
-resign "$TEMP_DIR/Payload/$APP_NAME" NO
+resign "$TEMP_DIR/Payload/$APP_NAME"
 
 # Repackage quietly
 echo "Repackaging as $NEW_FILE" >&2

--- a/lib/sigh/resign.rb
+++ b/lib/sigh/resign.rb
@@ -59,7 +59,7 @@ module Sigh
     def get_inputs(options, args)
       ipa = args.first || find_ipa || ask('Path to ipa file: ')
       signing_identity = options.signing_identity || ask_for_signing_identity
-      provisioning_profile = options.provisioning_profiles.each_slice(2).to_a || options.provisioning_profile || find_provisioning_profile || ask('Path to provisioning file: ')
+      provisioning_profile = options.provisioning_profiles || options.provisioning_profile || find_provisioning_profile || ask('Path to provisioning file: ')
 
       return ipa, signing_identity, provisioning_profile
     end

--- a/lib/sigh/resign.rb
+++ b/lib/sigh/resign.rb
@@ -47,7 +47,7 @@ module Sigh
         ptn = 'Assuming Distribution Identity'
       end
 
-      if output.include?(ptn)
+      if output.include?(ptn) && $?.to_i == 0
         Helper.log.info "Successfully signed #{ipa}!".green
         true
       else

--- a/lib/sigh/resign.rb
+++ b/lib/sigh/resign.rb
@@ -18,7 +18,10 @@ module Sigh
     def resign(ipa, signing_identity, provisioning_profiles)
       resign_path = find_resign_path
       signing_identity = find_signing_identity(signing_identity)
-      provisioning_profiles = [provisioning_profiles] unless provisioning_profiles.is_a?(Enumerable)
+
+      unless provisioning_profiles.kind_of?(Enumerable)
+        provisioning_profiles = [provisioning_profiles]
+      end
 
       # validate that we have valid values for all these params, we don't need to check signing_identity because `find_signing_identity` will only ever return a valid value
       validate_params(resign_path, ipa, provisioning_profiles)


### PR DESCRIPTION
Resigning an application with nested applications and app extensions requires to provide a provisioning profile for each app.

This pull request provides a fix for #131.

The `resign.sh` script accepts the provisioning profiles using the `-m bundle-identifier=xxxxx.mobileprovision` option. `bundle-identifier` is the current bundle identifier of an application, `xxxxx.mobileprovision` is the path to the related provisioning profile. The option may be provided multiple times.

I couldn't find a nice way to do the same with the `sigh` command. Instead, the bundle identifiers and provisioning profiles are provided as a comma-separated list `--provisioning_profiles bundle_id1,provisioning_profile1,bundle_id2,provisioning_profile2`. I'm not really happy with that. Improvements are welcome.

When using the `Sigh::Resign::resign` methods, the `provisioning_profile` parameter can be a Hash or an Array of tuples.
