### PR TITLE
When re-signing an IPA, preserve any symlinks when re-archiving the IPA.

### DIFF
--- a/lib/assets/resign.sh
+++ b/lib/assets/resign.sh
@@ -440,7 +440,7 @@ echo "Repackaging as $NEW_FILE" >&2
 # Zip all the contents, saving the zip file in the above directory
 # Navigate back to the orignating directory (sending the output to null)
 pushd "$TEMP_DIR" > /dev/null
-zip -qr "../$TEMP_DIR.ipa" *
+zip -qry "../$TEMP_DIR.ipa" *
 popd > /dev/null
 
 # Move the resulting ipa to the target destination


### PR DESCRIPTION
We are using Xamarin, which currently maintains some architecture specific directories within the IPA for 32 and 64 bit differences.  Much of the code is the same between the architectures, so we use some symlinks to minimize the size of the IPA.  Adding this switch preserves the embedded symlinks within the IPA when re-archiving after re-signing.

Using sigh 0.10.9 and resigning an IPA with "sign resign".
