### PR TITLE
Use entitlements from provisioning profile

### DIFF
--- a/lib/sigh/resign.rb
+++ b/lib/sigh/resign.rb
@@ -32,22 +32,15 @@ module Sigh
         resign_path.shellescape,
         ipa.shellescape,
         signing_identity.shellescape,
-        "-r yes",
+        "-u",
         provisioning_options,
         ipa.shellescape
       ].join(' ')
 
       puts command.magenta
-      output = `#{command}`
-      puts output
+      puts `#{command}`
 
-      if signing_identity =~ /^iPhone Developer:*/
-        ptn = 'Assuming Development Identity'
-      else
-        ptn = 'Assuming Distribution Identity'
-      end
-
-      if output.include?(ptn) && $?.to_i == 0
+      if $?.to_i == 0
         Helper.log.info "Successfully signed #{ipa}!".green
         true
       else

--- a/lib/sigh/resign.rb
+++ b/lib/sigh/resign.rb
@@ -32,7 +32,6 @@ module Sigh
         resign_path.shellescape,
         ipa.shellescape,
         signing_identity.shellescape,
-        "-u",
         provisioning_options,
         ipa.shellescape
       ].join(' ')


### PR DESCRIPTION
When resigning an application, `resign.sh` extracts the entitlements from the application, performs some changes (modifying `application-identifier`, `keychain-access-groups` and `com.apple.developer.team-identifier`, adding or removing `beta-reports-active`) then reapply them.

I think this is:
- **unnecessary**: Xcode no longer use an `Entitlements.plist` file but instead automatically updates the provisioning profile, which means the provisioning profile is very likely to contain the correct entitlements.
- **error-prone**: When resigning the application with a different provisioning profile, there may be conflicts between the previous entitlements and the provisioning profile's entitlements that would prevent the application from installing. That case happened to me: the original entitlements had data protection enabled while the new provisioning profile didn't contain that entitlement. It can be quite confusing for the user.
- **fragile**: Nobody nows what entitlement Apple may add in the future that could break the application when changing the provisioning profile.

I'm aware of no workflow where one would want the code signature's entitlements to differ from the provisioning profile's entitlements. So in my opinion, it's safer and simpler to drop them and use the new provisioning profile's entitlements instead.

But I may be wrong.

This pull request changes the `resign.sh` script to extract the entitlements from the provisioning profile and pass them to `codesign`. Also the entitlements are copied to `archived-expanded-entitlements.xcent` (Xcode does it so… why not?).
