### PR TITLE
Escaping provisioning profile params when resigning

### DIFF
--- a/lib/sigh/resign.rb
+++ b/lib/sigh/resign.rb
@@ -32,7 +32,7 @@ module Sigh
         resign_path.shellescape,
         ipa.shellescape,
         signing_identity.shellescape,
-        provisioning_options,
+        provisioning_options.shellescape,
         ipa.shellescape
       ].join(' ')
 


### PR DESCRIPTION
The constructed resign command would fail if provisioning profile path contains spaces.
