### PR TITLE
Incorrect argument on Advanced example

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ If you generated your `ipa` file but want to apply a different code signing onto
 
 You can pass more information using the command line:
 
-    sigh resign ./path/app.ipa -i "iPhone Distribution: Felix Krause" -p "my.mobileprovision"
+    sigh resign ./path/app.ipa -i "iPhone Distribution: Felix Krause" -n "my.mobileprovision"
 
 # Manage
 


### PR DESCRIPTION
I couldn't find the `-p` option on the `--help` command. Maybe you moved to to `-n`?
