### PR TITLE
Add support for homonymous entities

### DIFF
--- a/lib/sigh/resign.rb
+++ b/lib/sigh/resign.rb
@@ -19,11 +19,13 @@ module Sigh
       resign_path = find_resign_path
       signing_identity = find_signing_identity(signing_identity)
 
+      UI.important "Signing identity '#{signing_identity}' may have expired." unless signing_identity.valid?
+
       unless provisioning_profiles.kind_of?(Enumerable)
         provisioning_profiles = [provisioning_profiles]
       end
 
-      # validate that we have valid values for all these params, we don't need to check signing_identity because `find_signing_identity` will only ever return a valid value
+      # validate that we have valid values for all these params
       validate_params(resign_path, ipa, provisioning_profiles)
       entitlements = "-e #{entitlements}" if entitlements
       provisioning_options = provisioning_profiles.map { |fst, snd| "-p #{[fst, snd].compact.map(&:shellescape).join('=')}" }.join(' ')
@@ -31,7 +33,7 @@ module Sigh
       command = [
         resign_path.shellescape,
         ipa.shellescape,
-        signing_identity.shellescape,
+        signing_identity.sha1.shellescape,
         provisioning_options, # we are aleady shellescaping this above, when we create the provisioning_options from the provisioning_profiles
         entitlements,
         ipa.shellescape
@@ -74,19 +76,19 @@ module Sigh
       Dir[File.join(Dir.pwd, '*.entitlements')].sort { |a, b| File.mtime(a) <=> File.mtime(b) }.first
     end
 
-    def find_signing_identity(signing_identity)
-      until (signing_identity = sha1_for_signing_identity(signing_identity))
+    def find_signing_identity(query)
+      signing_identity = signing_identity_for_query(query)
+      until signing_identity
         UI.error "Couldn't find signing identity '#{signing_identity}'."
-        signing_identity = ask_for_signing_identity
+        query = ask_for_signing_identity
+        signing_identity = signing_identity_for_query(query)
       end
 
       signing_identity
     end
 
-    def sha1_for_signing_identity(signing_identity)
-      identities = installed_identities
-      return signing_identity if identities.keys.include?(signing_identity)
-      identities.key(signing_identity)
+    def signing_identity_for_query(query)
+      installed_identities.find { |identity| identity.sha1 == query || identity.name == query }
     end
 
     def validate_params(resign_path, ipa, provisioning_profiles)
@@ -120,32 +122,61 @@ module Sigh
 
     # Hash of available signing identities
     def installed_identities
-      available = `security find-identity -v -p codesigning`
+      available = `security find-identity -p codesigning`
       ids = {}
       available.split("\n").each do |current|
         begin
-          match = current.match(/.*([0-9A-Z]{40}) \"(.*)\"/)
+          match = current.match(/.*([0-9A-Z]{40}) \"(.*)\"(\s+\((.*)\))?/)
           sha1 = match[1]
           name = match[2]
-          ids[sha1] = name
+          issue = match[4]
+          ids[sha1] = SigningIdentity.new(sha1, name, issue)
         rescue
           nil
         end # the last line does not match
       end
 
-      ids
+      ids.values.select(&:may_be_valid?).sort_by do |identity|
+        [identity.name, identity.valid? ? 0 : 1]
+      end
     end
 
     def installed_identity_descriptions
       descriptions = []
-      installed_identities.group_by { |sha1, name| name }.each do |name, identities|
-        descriptions << name
+      installed_identities.group_by(&:name).each do |name, identities|
+        descriptions << (identities.any?(&:valid?) ? name.black : name.white)
         # Show SHA-1 for homonymous identities
-        descriptions += identities.map do |sha1, _|
-          "\t#{sha1}"
+        descriptions += identities.map do |identity|
+          text = "\t#{identity.sha1}"
+          identity.valid? ? text.black : text.white
         end if identities.count > 1
       end
       descriptions
+    end
+
+    class SigningIdentity
+      attr_reader :sha1, :name, :issue
+
+      def initialize(sha1, name, issue)
+        @sha1 = sha1
+        @name = name
+        @issue = issue
+      end
+
+      def valid?
+        @issue.nil?
+      end
+
+      def may_be_valid?
+        # Because of WWDR Intermediate Certificate expiration, valid certificates may be reported as expired.
+        # So we need to accept expired certificates for the moment.
+        # https://developer.apple.com/support/certificates/expiration
+        [nil, 'CSSMERR_TP_CERT_EXPIRED'].include? @issue
+      end
+
+      def to_s
+        "#{sha1} \"#{name}\""
+      end
     end
   end
 end


### PR DESCRIPTION
Your keychain may contain homonymous entities (many certificates with the same subject name) when you request a new certificate from Apple without deleting the previous one (because you don't want to regenerate all your provisioning profiles right now).

This commit allows to distinguish between homonymous entities by using the SHA-1 (which codesign accepts as an identity) of the certificate instead of its subject name. If you provide a SHA-1, it will be accepted. If you provide a subject name (like normal people do), it will be automatically substituted with the SHA-1 of the first matching certificate during the validation of the parameter.

Moreover, when displaying the list of available identities, homonymous certificates are grouped together and their SHA-1 are also displayed.
### Before:

``` bash
$ sigh resign GLaDOS.ipa
[18:51:24]: Available identities: 
    iPhone Distribution: Aperture Science (5EG96SA3GS)
    iPhone Distribution: Aperture Science (5EG96SA3GS)
    iPhone Developer: Cave Johnson (9EKSC7UTQC)
    iPhone Developer: Caroline (VA8D49WR55)

Signing Identity: 
```
### After

``` bash
$ sigh resign GLaDOS.ipa
[18:51:53]: Available identities: 
    iPhone Distribution: Aperture Science (5EG96SA3GS)
        1C68EA370B40C06FCAF7F26C8B1DBA9D9CAF5DEA
        035C2E0EE5B26D228AA7886CA5955C3B20B46782
    iPhone Developer: Cave Johnson (9EKSC7UTQC)
    iPhone Developer: Caroline (VA8D49WR55)

Signing Identity: 
```
