### PR TITLE
Adding the version number override option

### DIFF
--- a/bin/sigh
+++ b/bin/sigh
@@ -61,6 +61,7 @@ class SighApplication
       c.syntax = 'sigh resign'
       c.description = 'Resigns an existing ipa file with the given provisioning profile'
       c.option '-i', '--signing_identity STRING', String, 'The signing identity to use. Must match the one defined in the provisioning profile.'
+      c.option '-x', '--version_number STRING', String, 'Version number to force binary to use'
       c.option '-p', '--provisioning_profile PATH', String, '(or BUNDLE_ID=PATH) The path to the provisioning profile which should be used.'\
                'Can be provided multiple times if the application contains nested applications and app extensions, which need their own provisioning profile.'\
                'The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.',

--- a/lib/sigh/resign.rb
+++ b/lib/sigh/resign.rb
@@ -6,16 +6,16 @@ module Sigh
     def run(options, args)
       # get the command line inputs and parse those into the vars we need...
 
-      ipa, signing_identity, provisioning_profiles, entitlements = get_inputs(options, args)
+      ipa, signing_identity, provisioning_profiles, entitlements, version = get_inputs(options, args)
       # ... then invoke our programmatic interface with these vars
-      resign(ipa, signing_identity, provisioning_profiles, entitlements)
+      resign(ipa, signing_identity, provisioning_profiles, entitlements, version)
     end
 
-    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements)
-      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements)
+    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version)
+      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version)
     end
 
-    def resign(ipa, signing_identity, provisioning_profiles, entitlements)
+    def resign(ipa, signing_identity, provisioning_profiles, entitlements, version)
       resign_path = find_resign_path
       signing_identity = find_signing_identity(signing_identity)
 
@@ -27,6 +27,7 @@ module Sigh
       validate_params(resign_path, ipa, provisioning_profiles)
       entitlements = "-e #{entitlements}" if entitlements
       provisioning_options = provisioning_profiles.map { |fst, snd| "-p #{[fst, snd].compact.map(&:shellescape).join('=')}" }.join(' ')
+      version = "-n #{version}" if version
 
       command = [
         resign_path.shellescape,
@@ -34,6 +35,7 @@ module Sigh
         signing_identity.shellescape,
         provisioning_options, # we are aleady shellescaping this above, when we create the provisioning_options from the provisioning_profiles
         entitlements,
+        version,
         ipa.shellescape
       ].join(' ')
 
@@ -54,8 +56,9 @@ module Sigh
       signing_identity = options.signing_identity || ask_for_signing_identity
       provisioning_profiles = options.provisioning_profile || find_provisioning_profile || ask('Path to provisioning file: ')
       entitlements = options.entitlements || find_entitlements
+      version = options.version_number || nil
 
-      return ipa, signing_identity, provisioning_profiles, entitlements
+      return ipa, signing_identity, provisioning_profiles, entitlements, version
     end
 
     def find_resign_path


### PR DESCRIPTION
The shell script can take a -n # option to resign with a new version.  In this case add a '-x' option (-n/-v are taken).   grab the arg and pass it on down to the shell resign script.
